### PR TITLE
Fix: Preferences toggle padding causing text wrapping in FF

### DIFF
--- a/components/Header/main.css
+++ b/components/Header/main.css
@@ -155,7 +155,7 @@
 }
 
 .report-header__pref-toggle {
-  @apply su-py-26 su-px-29 su-h-[186px] su-bg-white dark:aria-pressed:su-bg-transparent dark:hover:su-bg-transparent dark:hover:su-text-white aria-pressed:dark:su-text-white hover:su-bg-transparent dark:su-bg-black-true after:su-transition-none su-transition before:su-transition dark:after:su-rotate-180 before:su-absolute before:-su-z-10 before:-su-m-2 after:su-absolute after:-su-z-10 before:su-top-0 before:su-bottom-0 before:su-right-0 before:su-left-0 after:su-top-0 after:su-bottom-0 after:su-right-0 after:su-left-0 su-relative su-text-center;
+  @apply su-py-26 su-px-5 su-h-[18.6rem] su-bg-white dark:aria-pressed:su-bg-transparent dark:hover:su-bg-transparent dark:hover:su-text-white aria-pressed:dark:su-text-white hover:su-bg-transparent dark:su-bg-black-true after:su-transition-none su-transition before:su-transition dark:after:su-rotate-180 before:su-absolute before:-su-z-10 before:-su-m-2 after:su-absolute after:-su-z-10 before:su-top-0 before:su-bottom-0 before:su-right-0 before:su-left-0 after:su-top-0 after:su-bottom-0 after:su-right-0 after:su-left-0 su-relative su-text-center;
   border-radius: 9px;
   background-clip: padding-box;
   border: 3px solid transparent;


### PR DESCRIPTION
# NOT READY FOR REVIEW
- (Edit the above to reflect status)

# Summary
- Minor CSS adjustment for preferences tray buttons.

# Review Tasks

## Setup tasks and/or behavior to test

1. In Firefox, Verify the buttons are not wrapping.

# Associated Issues and/or People
- JIRA ticket(s) - [STANFORD-946](https://squizgroup.atlassian.net/browse/STANFORD-946) 
- @iamrentman just fyi - I will merge this across environments
