### PR TITLE
UCP-3343 - Update maxItems in Image Gallery to 20

### DIFF
--- a/components/image-gallery-modal/manifest.json
+++ b/components/image-gallery-modal/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "image-gallery-modal",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "namespace": "stanford-components",
   "description": "An image gallery that opens in a modal.",
   "displayName": "Image gallery with modal",
@@ -54,7 +54,7 @@
                 "title": "Images",
                 "type": "array",
                 "minItems": 4,
-                "maxItems": 10,
+                "maxItems": 20,
                 "items": {
                   "type": "object",
                   "required": [

--- a/components/image-gallery-modal/preview.data.json
+++ b/components/image-gallery-modal/preview.data.json
@@ -26,6 +26,62 @@
       {
         "image": "matrix-asset://api-identifier/125802",
         "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
+      },
+      {
+        "image": "matrix-asset://api-identifier/125802",
+        "caption": "This is a caption for the image."
       }
     ],
     "caption": "This is an optional caption for the whole gallery This is an optional caption for the whole gallery This is an optional caption for the whole gallery This is an optional caption for the whole gallery This is an optional caption for the whole gallery This is an optional caption for the whole gallery",

--- a/components/image-gallery-modal/preview.data.json
+++ b/components/image-gallery-modal/preview.data.json
@@ -26,62 +26,6 @@
       {
         "image": "matrix-asset://api-identifier/125802",
         "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
-      },
-      {
-        "image": "matrix-asset://api-identifier/125802",
-        "caption": "This is a caption for the image."
       }
     ],
     "caption": "This is an optional caption for the whole gallery This is an optional caption for the whole gallery This is an optional caption for the whole gallery This is an optional caption for the whole gallery This is an optional caption for the whole gallery This is an optional caption for the whole gallery",

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -1973,6 +1973,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 }
 .su-bg-gradient-light-red-h-reverse{background-image:linear-gradient(to left, var(--tw-gradient-stops));--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
 :is(.su-dark .su-bg-gradient-light-red-h-reverse){background-image:linear-gradient(to top left, var(--tw-gradient-stops));--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:rgb(39 153 137 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #279989 var(--tw-gradient-via-position), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+.su-input{display:block;border-color:#D5D5D4;color:#2E2D29;font-size:1.8rem;line-height:1.3}
 .su-button{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;cursor:pointer;display:inline-block;border:none;font-weight:400;line-height:1;text-align:center;text-decoration:none;width:auto;transition:background-color 0.25s ease-in-out, color 0.25s ease-in-out;padding:1rem 2rem;background-color:#B1040E;color:#fff;}
 .su-button:active, .su-button:hover, .su-button:focus{text-decoration:underline}
 .su-button:hover, .su-button:focus{background-color:#2E2D29;color:#fff}
@@ -2193,6 +2194,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\!su-absolute{position:absolute !important}
 .su-absolute{position:absolute}
 .su-relative{position:relative}
+.su--bottom-1{bottom:-0.1rem}
 .su--left-80{left:-8rem}
 .su-bottom-0{bottom:0}
 .su-bottom-13{bottom:1.3rem}
@@ -2221,6 +2223,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-right-48{right:4.8rem}
 .su-right-60{right:6rem}
 .su-right-70{right:7rem}
+.su-right-auto{right:auto}
 .su-top-0{top:0}
 .su-top-1{top:0.1rem}
 .su-top-1\/2{top:50%}
@@ -2229,7 +2232,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-top-2{top:0.2rem}
 .su-top-3{top:0.3rem}
 .su-top-43{top:4.3rem}
-.su-top-45{top:4.5rem}
 .su-top-5{top:0.5rem}
 .su-top-7{top:0.7rem}
 .su-top-72{top:7.2rem}
@@ -2281,6 +2283,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mx-\[-20px\]{margin-left:-20px;margin-right:-20px}
 .su-mx-auto{margin-left:auto;margin-right:auto}
 .su-my-0{margin-top:0;margin-bottom:0}
+.su-my-15{margin-top:1.5rem;margin-bottom:1.5rem}
 .su-my-20{margin-top:2rem;margin-bottom:2rem}
 .su-my-27{margin-top:2.7rem;margin-bottom:2.7rem}
 .su-my-38{margin-top:3.8rem;margin-bottom:3.8rem}
@@ -2349,6 +2352,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mr-8{margin-right:0.8rem}
 .su-mr-auto{margin-right:auto}
 .su-mt-0{margin-top:0}
+.su-mt-01em{margin-top:0.1em}
 .su-mt-10{margin-top:1rem}
 .su-mt-11{margin-top:1.1rem}
 .su-mt-12{margin-top:1.2rem}
@@ -2417,7 +2421,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-2{height:0.2rem}
 .su-h-20{height:2rem}
 .su-h-21{height:2.1rem}
-.su-h-23{height:2.3rem}
 .su-h-28{height:2.8rem}
 .su-h-3{height:0.3rem}
 .su-h-32{height:3.2rem}
@@ -2520,6 +2523,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-min-w-full{min-width:100%}
 .su-max-w-1500{max-width:150rem}
 .su-max-w-160{max-width:16rem}
+.su-max-w-550{max-width:55rem}
 .su-max-w-900{max-width:90rem}
 .su-max-w-\[1026px\]{max-width:1026px}
 .su-max-w-\[103px\]{max-width:103px}
@@ -2721,6 +2725,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-to-digital-red-dark{--tw-gradient-to:#820000 var(--tw-gradient-to-position)}
 .su-to-digital-red-light{--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
 .su-to-olive{--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+.su-to-plum{--tw-gradient-to:#620059 var(--tw-gradient-to-position)}
 .su-to-50\%{--tw-gradient-to-position:50%}
 .su-bg-cover{background-size:cover}
 .su-bg-center{background-position:center}
@@ -2749,6 +2754,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-p-7{padding:0.7rem}
 .su-p-9{padding:0.9rem}
 .su-px-0{padding-left:0;padding-right:0}
+.su-px-18{padding-left:1.8rem;padding-right:1.8rem}
 .su-px-20{padding-left:2rem;padding-right:2rem}
 .su-px-22{padding-left:2.2rem;padding-right:2.2rem}
 .su-px-29{padding-left:2.9rem;padding-right:2.9rem}
@@ -2850,6 +2856,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-align-middle{vertical-align:middle}
 .su-font-sans{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif}
 .su-font-serif{font-family:"Source Serif 4", "Source Serif Pro", Georgia, Times, "Times New Roman", serif}
+.\!su-text-19{font-size:1.9rem !important}
 .\!su-text-23{font-size:2.3rem !important}
 .su-text-12{font-size:1.2rem}
 .su-text-14{font-size:1.4rem}


### PR DESCRIPTION

# READY FOR REVIEW

# Summary
- Updating the maxItems allowed in the image gallery to 20

# Review By (Date)
- Asap

# Criticality
- 5

# Review Tasks

## Setup tasks and/or behavior to test

1. Go here: https://sug-web.matrix.squiz.cloud/developreport/stories/ucp-3343-image-gallery-maxitem-updates/_nocache 
2. Check out the image gallery, you should see that the gallery now supports 20 images
3. Verify that 20 images are displayed in the gallery

# Associated Issues and/or People
- [UCP-3343](https://stanfordits.atlassian.net/browse/UCP-3343)


[UCP-3343]: https://stanfordits.atlassian.net/browse/UCP-3343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ