### PR TITLE
Hotfix Popular Stories STANFORD-1078

### DIFF
--- a/components/popular-stories-cf/manifest.json
+++ b/components/popular-stories-cf/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "popular-stories-cf",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "namespace": "stanford-components",
   "description": "Displays a list of popular stories.",
   "displayName": "Popular Stories",

--- a/components/popular-stories-cf/scripts/popularStoriesFetcher.js
+++ b/components/popular-stories-cf/scripts/popularStoriesFetcher.js
@@ -7,14 +7,13 @@ export default async function popularStoriesFetcher(urls, { FB_JSON_URL }) {
 
   for (let i = 0; i < urls.length; i++) {
     // eslint-disable-next-line security/detect-object-injection
-    if (assets.length <= 4) assets.push(`assetHref:"${urls[i]}"`);
+    assets.push(`assetHref:"${urls[i]}"`);
   }
 
-  adapter.url = `${FB_JSON_URL}?profile=stanford-report-push-search&collection=sug~sp-stanford-report-search&num_ranks=5&query=[${assets.join(
+  adapter.url = `${FB_JSON_URL}?profile=stanford-report-push-search&collection=sug~sp-stanford-report-search&num_ranks=10&query=[${assets.join(
     " "
-  )}]`;
-
+  )}]&query_not=[taxonomyContentTypeId:28201 taxonomyContentTypeId:28216 taxonomyContentTypeId:28210]`;
   const data = await adapter.fetch();
 
-  return data?.response?.resultPacket?.results;
+  return data?.response?.resultPacket?.results.slice(0, 5);
 }

--- a/components/popular-stories-cf/server.jsx
+++ b/components/popular-stories-cf/server.jsx
@@ -44,7 +44,7 @@ export default async (args, info) => {
                       ]
                   }
                   orderBy: [count_DESC]
-                  limit: 5
+                  limit: 10
               ) {
                   count
                   dimensions {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Hot fix for Popular Stories STANFORD-1078

# Review By (Date)
- ASAP

# Criticality
- 10

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch and preview locally, or
2. View hotfix here https://sug-web.matrix.squiz.cloud/releasereport/stories/rams-head-presents-chicago/_nocache
3. There should not be any Leadership messages present.


# Associated Issues and/or People
- JIRA ticket(s) - [STANFORD-1078](https://squizgroup.atlassian.net/browse/STANFORD-1078)
- @iamrentman @broleomo to launch this to PROD we just need to change the [CS PROD set](https://dxp.squiz.cloud/organization/sug-9278/component-service/component-sets/su-cs-global/stanford-components/popular-stories-cf) to use the latest 2.0.4 version and then update Sidebar #128860 to use this version.
- This is a server render only issue, so no git deploy is needed. This PR can be merged in anytime.
