### PR TITLE
Feature/stanford 1074

### DIFF
--- a/components/leadership-messages/manifest.json
+++ b/components/leadership-messages/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "leadership-messages",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "namespace": "stanford-components",
   "description": "Links to leadership messages displayed in a grid.",
   "displayName": "Leadership messages",

--- a/components/leadership-messages/manifest.json
+++ b/components/leadership-messages/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
-  "name": "development-leadership-messages",
+  "name": "leadership-messages",
   "version": "2.0.6",
   "namespace": "stanford-components",
   "description": "Links to leadership messages displayed in a grid.",

--- a/components/leadership-messages/manifest.json
+++ b/components/leadership-messages/manifest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
-  "name": "leadership-messages",
+  "name": "development-leadership-messages",
   "version": "2.0.6",
   "namespace": "stanford-components",
   "description": "Links to leadership messages displayed in a grid.",
@@ -69,7 +69,7 @@
               "searchQuery": {
                 "type": "string",
                 "title": "The Funnelback search query",
-                "default": "?f.Content+Type%7CtaxonomyContentTypeText=Leadership+messages&log=false&taxonomyContentTypeText=Leadership+Messages&profile=stanford-report-push-search_preview&query=%21null&collection=sug~sp-stanford-report-search&num_ranks=3"
+                "default": "?profile=stanford-report-push-search&collection=sug~sp-stanford-report-search&meta_taxonomyContentTypeId=28201&sort=date"
               }
             }
           }

--- a/components/leadership-messages/preview.data.json
+++ b/components/leadership-messages/preview.data.json
@@ -5,6 +5,6 @@
     "ctaUrl": "matrix-asset://api-identifier/89422"
   },
   "contentConfiguration": {
-    "searchQuery": "?profile=stanford-report-push-search&num_ranks=3&collection=sug~sp-stanford-report-search&sort=date&meta_taxonomyContentTypeText=Leadership%20messages"
+    "searchQuery": "?profile=stanford-report-push-search&collection=sug~sp-stanford-report-search&meta_taxonomyContentTypeId=28201&sort=date"
   }
 }

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -2357,10 +2357,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-32{height:3.2rem}
 .su-h-35{height:3.5rem}
 .su-h-4{height:0.4rem}
+.su-h-43{height:4.3rem}
 .su-h-44{height:4.4rem}
 .su-h-48{height:4.8rem}
 .su-h-50{height:5rem}
 .su-h-6{height:0.6rem}
+.su-h-60{height:6rem}
 .su-h-72{height:7.2rem}
 .su-h-90{height:9rem}
 .su-h-\[101\%\]{height:101%}


### PR DESCRIPTION
# WIP


# Summary
This PR updates the default FB query for the leadership messages component.

# Review By (Date)
n/a

# Criticality
5

# Review Tasks
Details are here: https://squizgroup.atlassian.net/browse/STANFORD-1074
When adding a new leadership message component, the default search query should be the one provided in the ticket above.

## Setup tasks and/or behavior to test
Behaviour should be that any new leadership messages component should have a default link, see the support ticket in review tasks for the new default query.

# Associated Issues and/or People
- JIRA ticket(s) - STANFORD-1074
- Other PRs: n/a
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here) @JBCSU @iamrentman @broleomo 
- Note: the manifest version of the component is bumped up to 2.0.7 from 2.0.6, a redeployment of the component will bring in the new default search link.