### PR TITLE
STANFORD-1045: css changes main header

### DIFF
--- a/components/Header/main.css
+++ b/components/Header/main.css
@@ -140,8 +140,7 @@
 }
 
 .report-header__menu-tray[aria-hidden="false"] .report-header__primary-nav,
-.report-header__preferences-tray[aria-hidden="false"]
-  .report-header__preferences {
+.report-header__preferences-tray[aria-hidden="false"] .report-header__preferences {
   height: 100dvh !important;
 }
 
@@ -277,15 +276,13 @@
 }
 
 .report-header__search input {
-  filter: drop-shadow(0px 0px 38px rgba(0, 0, 0, 0))
-    drop-shadow(0px 0px 12px rgba(0, 0, 0, 0));
+  filter: drop-shadow(0px 0px 38px rgba(0, 0, 0, 0)) drop-shadow(0px 0px 12px rgba(0, 0, 0, 0));
   transition: all 0.25s ease;
 }
 
 .report-header__search input:valid,
 .report-header__search .input-has-value input {
-  filter: drop-shadow(0px 0px 38px rgba(0, 0, 0, 0.25))
-    drop-shadow(0px 0px 12px rgba(0, 0, 0, 0.18));
+  filter: drop-shadow(0px 0px 38px rgba(0, 0, 0, 0.25)) drop-shadow(0px 0px 12px rgba(0, 0, 0, 0.18));
 }
 
 .report-header input[type="search"] {
@@ -308,10 +305,7 @@
 
 .report-header input:required:valid + .report-header__clear,
 .report-header .input-has-value + .report-header__clear,
-.report-header
-  .input-has-value
-  + .report-header__desktop-search-controls
-  .report-header__clear {
+.report-header .input-has-value + .report-header__desktop-search-controls .report-header__clear {
   display: block;
 }
 
@@ -405,6 +399,14 @@
   .report-header--story.report-header--collapsed .report-header__story p {
     max-height: 55px;
     overflow: hidden;
+  }
+
+  .report-header--story.report-header .report-header__story .report-header__next {
+    visibility: hidden;
+  }
+
+  .report-header--story.report-header--collapsed .report-header__story .report-header__next {
+    visibility: visible;
   }
 }
 

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -2096,11 +2096,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-pt-6{padding-top:9rem}}
 @media (min-width: 1500px){
 .su-rs-pt-6{padding-top:9.5rem}}
-.su-rs-mt-7{margin-top:5rem;}
-@media (min-width: 768px){
-.su-rs-mt-7{margin-top:10.8rem}}
-@media (min-width: 1500px){
-.su-rs-mt-7{margin-top:11.4rem}}
 .su-rs-pt-8{padding-top:6rem;}
 @media (min-width: 768px){
 .su-rs-pt-8{padding-top:12.6rem}}
@@ -2116,11 +2111,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-pt-9{padding-top:16.2rem}}
 @media (min-width: 1500px){
 .su-rs-pt-9{padding-top:17.1rem}}
-.su-rs-mb-9{margin-bottom:7rem;}
-@media (min-width: 768px){
-.su-rs-mb-9{margin-bottom:16.2rem}}
-@media (min-width: 1500px){
-.su-rs-mb-9{margin-bottom:17.1rem}}
 .su-rs-pb-9{padding-bottom:7rem;}
 @media (min-width: 768px){
 .su-rs-pb-9{padding-bottom:16.2rem}}
@@ -2155,9 +2145,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-big-paragraph{font-size:1.15em;line-height:1.4;}
 @media (min-width: 768px){
 .su-big-paragraph{line-height:1.5}}
-.su-card-paragraph{font-size:max(1.6rem, 0.93em);line-height:1.3;}
-@media (min-width: 768px){
-.su-card-paragraph{line-height:1.4}}
 .su-basefont-19{font-size:1.6rem;}
 @media (min-width: 768px){
 .su-basefont-19{font-size:1.8rem}}
@@ -2179,7 +2166,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\!su-absolute{position:absolute !important}
 .su-absolute{position:absolute}
 .su-relative{position:relative}
-.su--left-80{left:-8rem}
 .su-bottom-0{bottom:0}
 .su-bottom-13{bottom:1.3rem}
 .su-bottom-20{bottom:2rem}
@@ -2187,7 +2173,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bottom-4{bottom:0.4rem}
 .su-bottom-\[-100px\]{bottom:-100px}
 .su-left-0{left:0}
-.su-left-1{left:0.1rem}
 .su-left-1\/2{left:50%}
 .su-left-13{left:1.3rem}
 .su-left-20{left:2rem}
@@ -2197,7 +2182,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-left-9{left:0.9rem}
 .su-left-\[50\%\]{left:50%}
 .su-right-0{right:0}
-.su-right-1{right:0.1rem}
 .su-right-1\/2{right:50%}
 .su-right-10{right:1rem}
 .su-right-20{right:2rem}
@@ -2205,7 +2189,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-right-60{right:6rem}
 .su-right-70{right:7rem}
 .su-top-0{top:0}
-.su-top-1{top:0.1rem}
 .su-top-1\/2{top:50%}
 .su-top-10{top:1rem}
 .su-top-12{top:1.2rem}
@@ -2233,7 +2216,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-order-1{order:1}
 .su-order-2{order:2}
 .su-order-3{order:3}
-.su-order-first{order:-9999}
 .su-col-span-1{grid-column:span 1 / span 1}
 .su-col-span-5{grid-column:span 5 / span 5}
 .su-col-span-6{grid-column:span 6 / span 6}
@@ -2244,25 +2226,21 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\!su-m-0{margin:0 !important}
 .su-m-0{margin:0}
 .su--mx-18{margin-left:-1.8rem;margin-right:-1.8rem}
-.su-mx-0{margin-left:0;margin-right:0}
 .su-mx-\[-20px\]{margin-left:-20px;margin-right:-20px}
 .su-mx-auto{margin-left:auto;margin-right:auto}
 .su-my-0{margin-top:0;margin-bottom:0}
 .su-my-20{margin-top:2rem;margin-bottom:2rem}
 .su-my-38{margin-top:3.8rem;margin-bottom:3.8rem}
 .su-my-auto{margin-top:auto;margin-bottom:auto}
-.\!su-mb-0{margin-bottom:0 !important}
 .-su-mt-48{margin-top:-4.8rem}
 .su--ml-1em{margin-left:-1em}
 .su--ml-44{margin-left:-4.4rem}
 .su--ml-5{margin-left:-0.5rem}
 .su-mb-0{margin-bottom:0}
-.su-mb-10{margin-bottom:1rem}
 .su-mb-11{margin-bottom:1.1rem}
 .su-mb-12{margin-bottom:1.2rem}
 .su-mb-13{margin-bottom:1.3rem}
 .su-mb-15{margin-bottom:1.5rem}
-.su-mb-19{margin-bottom:1.9rem}
 .su-mb-20{margin-bottom:2rem}
 .su-mb-27{margin-bottom:2.7rem}
 .su-mb-3{margin-bottom:0.3rem}
@@ -2286,12 +2264,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-ml-1{margin-left:0.1rem}
 .su-ml-13{margin-left:1.3rem}
 .su-ml-4{margin-left:0.4rem}
-.su-ml-8{margin-left:0.8rem}
 .su-ml-\[-\.5rem\]{margin-left:-.5rem}
 .su-ml-\[-3px\]{margin-left:-3px}
 .su-ml-auto{margin-left:auto}
 .su-mr-0{margin-right:0}
-.su-mr-19{margin-right:1.9rem}
 .su-mr-2{margin-right:0.2rem}
 .su-mr-4{margin-right:0.4rem}
 .su-mr-44{margin-right:4.4rem}
@@ -2301,21 +2277,17 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mt-0{margin-top:0}
 .su-mt-11{margin-top:1.1rem}
 .su-mt-12{margin-top:1.2rem}
-.su-mt-14{margin-top:1.4rem}
 .su-mt-15{margin-top:1.5rem}
 .su-mt-17{margin-top:1.7rem}
 .su-mt-18{margin-top:1.8rem}
-.su-mt-19{margin-top:1.9rem}
 .su-mt-2{margin-top:0.2rem}
 .su-mt-27{margin-top:2.7rem}
 .su-mt-30{margin-top:3rem}
 .su-mt-32{margin-top:3.2rem}
 .su-mt-34{margin-top:3.4rem}
 .su-mt-38{margin-top:3.8rem}
-.su-mt-4{margin-top:0.4rem}
 .su-mt-45{margin-top:4.5rem}
 .su-mt-50{margin-top:5rem}
-.su-mt-61{margin-top:6.1rem}
 .su-mt-8{margin-top:0.8rem}
 .su-mt-9{margin-top:0.9rem}
 .su-mt-\[-63px\]{margin-top:-63px}
@@ -2334,13 +2306,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-aspect-\[1\/1\]{aspect-ratio:1/1}
 .su-aspect-\[16\/9\]{aspect-ratio:16/9}
 .su-aspect-\[3\/2\]{aspect-ratio:3/2}
-.su-size-100{width:10rem;height:10rem}
 .su-size-13{width:1.3rem;height:1.3rem}
-.su-size-14{width:1.4rem;height:1.4rem}
 .su-size-150{width:15rem;height:15rem}
 .su-size-18{width:1.8rem;height:1.8rem}
-.su-size-1em{width:1em;height:1em}
-.su-size-20{width:2rem;height:2rem}
 .su-size-200{width:20rem;height:20rem}
 .su-size-24{width:2.4rem;height:2.4rem}
 .su-size-30{width:3rem;height:3rem}
@@ -2353,16 +2321,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-2{height:0.2rem}
 .su-h-21{height:2.1rem}
 .su-h-28{height:2.8rem}
-.su-h-3{height:0.3rem}
 .su-h-32{height:3.2rem}
 .su-h-35{height:3.5rem}
 .su-h-4{height:0.4rem}
-.su-h-43{height:4.3rem}
 .su-h-44{height:4.4rem}
 .su-h-48{height:4.8rem}
 .su-h-50{height:5rem}
 .su-h-6{height:0.6rem}
-.su-h-60{height:6rem}
 .su-h-72{height:7.2rem}
 .su-h-90{height:9rem}
 .su-h-\[101\%\]{height:101%}
@@ -2395,7 +2360,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-max-h-\[103px\]{max-height:103px}
 .su-min-h-\[56px\]{min-height:56px}
 .su-w-08em{width:0.8em}
-.su-w-1{width:0.1rem}
 .su-w-1\/2{width:50%}
 .su-w-100{width:10rem}
 .su-w-2{width:0.2rem}
@@ -2406,9 +2370,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-w-3{width:0.3rem}
 .su-w-3\/4{width:75%}
 .su-w-32{width:3.2rem}
-.su-w-4{width:0.4rem}
 .su-w-44{width:4.4rem}
-.su-w-5{width:0.5rem}
 .su-w-5\/6{width:83.333333%}
 .su-w-50{width:5rem}
 .su-w-58{width:5.8rem}
@@ -2462,16 +2424,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-shrink-0{flex-shrink:0}
 .su-flex-grow{flex-grow:1}
 .su-grow{flex-grow:1}
-.su-basis-1{flex-basis:0.1rem}
-.-su-translate-x-1{--tw-translate-x:-0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .-su-translate-x-1\/2{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
-.-su-translate-y-1{--tw-translate-y:-0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .-su-translate-y-1\/2{--tw-translate-y:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-0{--tw-translate-x:0;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-1em{--tw-translate-x:1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-\[-50\%\]{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-0{--tw-translate-y:0;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
-.su-translate-y-1{--tw-translate-y:0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-\[-110px\]{--tw-translate-y:-110px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-\[-50\%\]{--tw-translate-y:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-rotate-180{--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -2480,7 +2438,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-cursor-pointer{cursor:pointer}
 .su-list-none{list-style-type:none}
 .su-grid-cols-1{grid-template-columns:repeat(1, minmax(0, 1fr))}
-.su-grid-cols-10{grid-template-columns:repeat(10, minmax(0, 1fr))}
 .su-grid-cols-2{grid-template-columns:repeat(2, minmax(0, 1fr))}
 .su-grid-cols-6{grid-template-columns:repeat(6, minmax(0, 1fr))}
 .su-grid-rows-2{grid-template-rows:repeat(2, minmax(0, 1fr))}
@@ -2499,31 +2456,24 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-justify-center{justify-content:center}
 .su-justify-between{justify-content:space-between}
 .su-justify-evenly{justify-content:space-evenly}
-.su-gap-0{gap:0}
 .su-gap-02em{gap:0.2em}
 .su-gap-10{gap:1rem}
 .su-gap-11{gap:1.1rem}
 .su-gap-12{gap:1.2rem}
-.su-gap-13{gap:1.3rem}
 .su-gap-15{gap:1.5rem}
 .su-gap-18{gap:1.8rem}
 .su-gap-19{gap:1.9rem}
 .su-gap-2{gap:0.2rem}
 .su-gap-20{gap:2rem}
-.su-gap-26{gap:2.6rem}
 .su-gap-27{gap:2.7rem}
 .su-gap-3{gap:0.3rem}
 .su-gap-30{gap:3rem}
 .su-gap-32{gap:3.2rem}
 .su-gap-34{gap:3.4rem}
 .su-gap-36{gap:3.6rem}
-.su-gap-40{gap:4rem}
-.su-gap-42{gap:4.2rem}
-.su-gap-48{gap:4.8rem}
 .su-gap-5{gap:0.5rem}
 .su-gap-6{gap:0.6rem}
 .su-gap-60{gap:6rem}
-.su-gap-61{gap:6.1rem}
 .su-gap-7{gap:0.7rem}
 .su-gap-8{gap:0.8rem}
 .su-gap-80{gap:8rem}
@@ -2575,11 +2525,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-border-black{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
 .su-border-black-10{--tw-border-opacity:1;border-color:rgb(234 234 234 / var(--tw-border-opacity))}
 .su-border-black-20{--tw-border-opacity:1;border-color:rgb(213 213 212 / var(--tw-border-opacity))}
-.su-border-black-30{--tw-border-opacity:1;border-color:rgb(192 192 191 / var(--tw-border-opacity))}
 .su-border-black-30\/30{border-color:rgb(192 192 191 / 0.3)}
 .su-border-black-60{--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity))}
-.su-border-digital-blue{--tw-border-opacity:1;border-color:rgb(0 108 184 / var(--tw-border-opacity))}
-.su-border-digital-blue-light{--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity))}
 .su-border-digital-green-dark{--tw-border-opacity:1;border-color:rgb(0 111 84 / var(--tw-border-opacity))}
 .su-border-digital-red{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
 .su-border-transparent{border-color:transparent}
@@ -2592,7 +2539,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bg-black-20{--tw-bg-opacity:1;background-color:rgb(213 213 212 / var(--tw-bg-opacity))}
 .su-bg-black-30{--tw-bg-opacity:1;background-color:rgb(192 192 191 / var(--tw-bg-opacity))}
 .su-bg-black-40{--tw-bg-opacity:1;background-color:rgb(171 171 169 / var(--tw-bg-opacity))}
-.su-bg-black-true{--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
 .su-bg-black\/\[0\.33\]{background-color:rgb(46 45 41 / 0.33)}
 .su-bg-digital-green-dark{--tw-bg-opacity:1;background-color:rgb(0 111 84 / var(--tw-bg-opacity))}
 .su-bg-digital-red{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
@@ -2615,7 +2561,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-to-digital-red{--tw-gradient-to:#B1040E var(--tw-gradient-to-position)}
 .su-to-digital-red-dark{--tw-gradient-to:#820000 var(--tw-gradient-to-position)}
 .su-to-digital-red-light{--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
-.su-to-olive{--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
 .su-to-50\%{--tw-gradient-to-position:50%}
 .su-bg-cover{background-size:cover}
 .su-bg-center{background-position:center}
@@ -2624,7 +2569,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-fill-transparent{fill:transparent}
 .su-fill-white{fill:#fff}
 .su-stroke-current{stroke:currentColor}
-.su-stroke-dark-mode-red{stroke:#EC0909}
 .su-stroke-digital-red{stroke:#B1040E}
 .su-stroke-white{stroke:#fff}
 .su-object-cover{object-fit:cover}
@@ -2658,12 +2602,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pb-108{padding-bottom:10.8rem}
 .su-pb-11{padding-bottom:1.1rem}
 .su-pb-12{padding-bottom:1.2rem}
-.su-pb-13{padding-bottom:1.3rem}
 .su-pb-15{padding-bottom:1.5rem}
 .su-pb-19{padding-bottom:1.9rem}
 .su-pb-20{padding-bottom:2rem}
 .su-pb-22{padding-bottom:2.2rem}
-.su-pb-26{padding-bottom:2.6rem}
 .su-pb-27{padding-bottom:2.7rem}
 .su-pb-32{padding-bottom:3.2rem}
 .su-pb-60{padding-bottom:6rem}
@@ -2688,8 +2630,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pr-10{padding-right:1rem}
 .su-pr-120{padding-right:12rem}
 .su-pr-20{padding-right:2rem}
-.su-pr-25{padding-right:2.5rem}
-.su-pr-30{padding-right:3rem}
 .su-pr-40{padding-right:4rem}
 .su-pr-45{padding-right:4.5rem}
 .su-pr-50{padding-right:5rem}
@@ -2728,7 +2668,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-23{font-size:2.3rem}
 .su-text-24{font-size:2.4rem}
 .su-text-25{font-size:2.5rem}
-.su-text-26{font-size:2.6rem}
 .su-text-28{font-size:2.8rem}
 .su-text-\[1\.433rem\]{font-size:1.433rem}
 .su-text-\[1\.4rem\]{font-size:1.4rem}
@@ -2815,13 +2754,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-black-60{--tw-text-opacity:1;color:rgb(118 118 116 / var(--tw-text-opacity))}
 .su-text-black-70{--tw-text-opacity:1;color:rgb(109 108 105 / var(--tw-text-opacity))}
 .su-text-black-90{--tw-text-opacity:1;color:rgb(67 66 62 / var(--tw-text-opacity))}
-.su-text-dark-mode-red{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .su-text-digital-blue{--tw-text-opacity:1;color:rgb(0 108 184 / var(--tw-text-opacity))}
-.su-text-digital-blue-vivid{--tw-text-opacity:1;color:rgb(5 151 255 / var(--tw-text-opacity))}
 .su-text-digital-red{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .su-text-digital-red-light{--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 .su-text-inherit{color:inherit}
-.su-text-palo-verde{--tw-text-opacity:1;color:rgb(39 153 137 / var(--tw-text-opacity))}
 .su-text-white{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .su-underline{text-decoration-line:underline}
 .su-no-underline{text-decoration-line:none}
@@ -2836,11 +2772,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-shadow-\[0px_3px_6px_0px_rgba\(0\,0\,0\,0\.1\)\]{--tw-shadow:0px 3px 6px 0px rgba(0,0,0,0.1);--tw-shadow-colored:0px 3px 6px 0px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 .su-shadow-\[0px_4px_7px_0px_rgba\(0\,0\,0\,0\.15\)\]{--tw-shadow:0px 4px 7px 0px rgba(0,0,0,0.15);--tw-shadow-colored:0px 4px 7px 0px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 .su-shadow-lg{--tw-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);--tw-shadow-colored:0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
-.su-shadow-black{--tw-shadow-color:#2E2D29;--tw-shadow:var(--tw-shadow-colored)}
-.su-shadow-black-60{--tw-shadow-color:#767674;--tw-shadow:var(--tw-shadow-colored)}
 .su-shadow-black-60\/50{--tw-shadow-color:rgb(118 118 116 / 0.5);--tw-shadow:var(--tw-shadow-colored)}
 .su-shadow-white{--tw-shadow-color:#fff;--tw-shadow:var(--tw-shadow-colored)}
-.su-ring-digital-blue-vivid{--tw-ring-opacity:1;--tw-ring-color:rgb(5 151 255 / var(--tw-ring-opacity))}
 .su-drop-shadow-\[0px_14px_28px_rgba\(0\,0\,0\,0\.20\)\]{--tw-drop-shadow:drop-shadow(0px 14px 28px rgba(0,0,0,0.20));filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)}
 .su-transition{transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .su-transition-all{transition-property:all;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
@@ -3051,8 +2984,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
   pointer-events: none;
 }
 .report-header__menu-tray[aria-hidden="false"] .report-header__primary-nav,
-.report-header__preferences-tray[aria-hidden="false"]
-  .report-header__preferences {
+.report-header__preferences-tray[aria-hidden="false"] .report-header__preferences {
   height: 100dvh !important;
 }
 .report-header__primary-nav {
@@ -3162,14 +3094,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
   max-height: 100vh;
 }
 .report-header__search input {
-  filter: drop-shadow(0px 0px 38px rgba(0, 0, 0, 0))
-    drop-shadow(0px 0px 12px rgba(0, 0, 0, 0));
+  filter: drop-shadow(0px 0px 38px rgba(0, 0, 0, 0)) drop-shadow(0px 0px 12px rgba(0, 0, 0, 0));
   transition: all 0.25s ease;
 }
 .report-header__search input:valid,
 .report-header__search .input-has-value input {
-  filter: drop-shadow(0px 0px 38px rgba(0, 0, 0, 0.25))
-    drop-shadow(0px 0px 12px rgba(0, 0, 0, 0.18));
+  filter: drop-shadow(0px 0px 38px rgba(0, 0, 0, 0.25)) drop-shadow(0px 0px 12px rgba(0, 0, 0, 0.18));
 }
 .report-header input[type="search"] {
   outline: none;
@@ -3188,10 +3118,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 }
 .report-header input:required:valid + .report-header__clear,
 .report-header .input-has-value + .report-header__clear,
-.report-header
-  .input-has-value
-  + .report-header__desktop-search-controls
-  .report-header__clear {
+.report-header .input-has-value + .report-header__desktop-search-controls .report-header__clear {
   display: block;
 }
 .report-header [aria-controls="search"][aria-expanded="true"] .icon-search,
@@ -3272,6 +3199,14 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
   .report-header--story.report-header--collapsed .report-header__story p {
     max-height: 55px;
     overflow: hidden;
+  }
+
+  .report-header--story.report-header .report-header__story .report-header__next {
+    visibility: hidden;
+  }
+
+  .report-header--story.report-header--collapsed .report-header__story .report-header__next {
+    visibility: visible;
   }
 }
 @media screen and (min-width: 992px) {
@@ -3680,13 +3615,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-group:focus-within .group-hocus-within\:su-translate-x-02em{--tw-translate-x:0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus-within .group-hocus-within\:su-translate-x-03em{--tw-translate-x:0.3em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus-within .group-hocus-within\:su-text-digital-red{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
-.su-group:focus-within .group-hocus-within\:su-text-digital-red-light{--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 .su-group:focus-within .group-hocus-within\:su-underline{text-decoration-line:underline}
 .su-group:hover .group-hocus-within\:su--translate-y-02em{--tw-translate-y:-0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:hover .group-hocus-within\:su-translate-x-02em{--tw-translate-x:0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:hover .group-hocus-within\:su-translate-x-03em{--tw-translate-x:0.3em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:hover .group-hocus-within\:su-text-digital-red{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
-.su-group:hover .group-hocus-within\:su-text-digital-red-light{--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 .su-group:hover .group-hocus-within\:su-underline{text-decoration-line:underline}
 :is(.su-dark .dark\:su-top-0){top:0}
 :is(.su-dark .dark\:su-block){display:block}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- When viewing a story, if tab through the page, the tab focus should not land on the ‘read next’ component in the site's header when it is not visible.
- 
# Criticality
- CSS only change for header

# Review Tasks

### To test
- Go to a story on the squiz development site on stanford report -> [https://sug-web.matrix.squiz.cloud/squizdevreport/stories/indigenous-women-celebrated-at-stanford-powwow/_nocache](https://sug-web.matrix.squiz.cloud/squizdevreport/stories/indigenous-women-celebrated-at-stanford-powwow/_nocache)
- tab through the header
- the tab focus should not land on the ‘read next’ component in the site's header when it is not visible

# Associated Issues and/or People
- JIRA ticket(s) - https://squizgroup.atlassian.net/browse/STANFORD-1045
