### PR TITLE
UCP-3414 Style radio buttons on Marketo forms

### DIFF
--- a/global/build/global.css
+++ b/global/build/global.css
@@ -1736,22 +1736,39 @@ Subscribe to Stanford Report Marketo form styles
 .marketo-sr-subscribe-form.mktoForm input[type="email"]:focus),:is(.su-dark 
 .marketo-sr-subscribe-form.mktoForm textarea:focus){border-color:rgb(133 204 255 / 0.8);--tw-border-opacity:1;border-bottom-color:rgb(133 204 255 / var(--tw-border-opacity))}
 /* Checkbox styles */
-.marketo-sr-subscribe-form.mktoForm .mktoCheckboxList{margin-top:2rem;display:grid;grid-template-columns:auto 1fr;column-gap:1.4rem;row-gap:2.4rem;padding:0}
-.marketo-sr-subscribe-form.mktoForm .mktoCheckboxList label{margin-top:0.1em;cursor:pointer;font-size:1.8rem;line-height:1.2}
-.su-peer:hover ~ .marketo-sr-subscribe-form.mktoForm .mktoCheckboxList label{text-decoration-line:underline}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]{width:auto;cursor:pointer;border-radius:0.3rem;border-width:2px;--tw-border-opacity:1;border-color:rgb(151 150 148 / var(--tw-border-opacity));--tw-text-opacity:1;color:rgb(0 108 184 / var(--tw-text-opacity))}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:checked{--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity))}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus{outline:2px solid transparent;outline-offset:2px;--tw-ring-offset-width:0px}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover{--tw-border-opacity:1;border-color:rgb(0 108 184 / var(--tw-border-opacity));--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);--tw-ring-color:rgb(133 204 255 / 0.4)}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover:checked{--tw-bg-opacity:1;background-color:rgb(0 84 143 / var(--tw-bg-opacity))}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus{--tw-border-opacity:1;border-color:rgb(0 108 184 / var(--tw-border-opacity));--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);--tw-ring-color:rgb(133 204 255 / 0.4)}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus:checked{--tw-bg-opacity:1;background-color:rgb(0 84 143 / var(--tw-bg-opacity))}
-:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]){--tw-border-opacity:1;border-color:rgb(192 192 191 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
-:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:checked){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 108 184 / var(--tw-bg-opacity))}
-:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-ring-color:rgb(5 151 255 / 0.6)}
-:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover:checked){--tw-bg-opacity:1;background-color:rgb(5 151 255 / var(--tw-bg-opacity))}
-:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-ring-color:rgb(5 151 255 / 0.6)}
-:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus:checked){--tw-bg-opacity:1;background-color:rgb(5 151 255 / var(--tw-bg-opacity))}
+.marketo-sr-subscribe-form.mktoForm .mktoCheckboxList,
+.marketo-sr-subscribe-form.mktoForm .mktoRadioList{margin-top:2rem;display:grid;grid-template-columns:auto 1fr;column-gap:1.4rem;row-gap:2.4rem;padding:0}
+.marketo-sr-subscribe-form.mktoForm .mktoCheckboxList label,
+.marketo-sr-subscribe-form.mktoForm .mktoRadioList label{margin-top:0.1em;cursor:pointer;font-size:1.8rem;line-height:1.2}
+.su-peer:hover ~ .marketo-sr-subscribe-form.mktoForm .mktoCheckboxList label,.su-peer:hover ~ 
+.marketo-sr-subscribe-form.mktoForm .mktoRadioList label{text-decoration-line:underline}
+.marketo-sr-subscribe-form.mktoForm input[type="checkbox"],
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]{width:auto;cursor:pointer;border-radius:0.3rem;border-width:2px;--tw-border-opacity:1;border-color:rgb(151 150 148 / var(--tw-border-opacity));--tw-text-opacity:1;color:rgb(0 108 184 / var(--tw-text-opacity))}
+.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:checked,
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:checked{--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity))}
+.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus,
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus{outline:2px solid transparent;outline-offset:2px;--tw-ring-offset-width:0px}
+.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover,
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:hover{--tw-border-opacity:1;border-color:rgb(0 108 184 / var(--tw-border-opacity));--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);--tw-ring-color:rgb(133 204 255 / 0.4)}
+.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover:checked,
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:hover:checked{--tw-bg-opacity:1;background-color:rgb(0 84 143 / var(--tw-bg-opacity))}
+.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus,
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus{--tw-border-opacity:1;border-color:rgb(0 108 184 / var(--tw-border-opacity));--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);--tw-ring-color:rgb(133 204 255 / 0.4)}
+.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus:checked,
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus:checked{--tw-bg-opacity:1;background-color:rgb(0 84 143 / var(--tw-bg-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]){--tw-border-opacity:1;border-color:rgb(192 192 191 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:checked),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:checked){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 108 184 / var(--tw-bg-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:hover){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-ring-color:rgb(5 151 255 / 0.6)}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover:checked),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:hover:checked){--tw-bg-opacity:1;background-color:rgb(5 151 255 / var(--tw-bg-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-ring-color:rgb(5 151 255 / 0.6)}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus:checked),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus:checked){--tw-bg-opacity:1;background-color:rgb(5 151 255 / var(--tw-bg-opacity))}
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]{border-radius:9999px}
 /* Marketo puts the asterisk before the label text(?) so
 // we use flexbox to switch the order and put the asterisk
 // after the label text.*/
@@ -2202,6 +2219,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bottom-38{bottom:3.8rem}
 .su-bottom-4{bottom:0.4rem}
 .su-bottom-\[-100px\]{bottom:-100px}
+.su-bottom-\[13px\]{bottom:13px}
+.su-bottom-\[27px\]{bottom:27px}
 .su-left-0{left:0}
 .su-left-1{left:0.1rem}
 .su-left-1\/2{left:50%}
@@ -2212,7 +2231,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-left-38{left:3.8rem}
 .su-left-8{left:0.8rem}
 .su-left-9{left:0.9rem}
+.su-left-\[13px\]{left:13px}
+.su-left-\[27px\]{left:27px}
+.su-left-\[3px\]{left:3px}
 .su-left-\[50\%\]{left:50%}
+.su-left-\[8px\]{left:8px}
+.su-left-\[9px\]{left:9px}
 .su-right-0{right:0}
 .su-right-1{right:0.1rem}
 .su-right-1\/2{right:50%}
@@ -2222,6 +2246,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-right-48{right:4.8rem}
 .su-right-60{right:6rem}
 .su-right-70{right:7rem}
+.su-right-auto{right:auto}
 .su-top-0{top:0}
 .su-top-1{top:0.1rem}
 .su-top-1\/2{top:50%}
@@ -2230,15 +2255,17 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-top-2{top:0.2rem}
 .su-top-3{top:0.3rem}
 .su-top-43{top:4.3rem}
-.su-top-45{top:4.5rem}
 .su-top-5{top:0.5rem}
 .su-top-7{top:0.7rem}
 .su-top-72{top:7.2rem}
 .su-top-9{top:0.9rem}
 .su-top-\[-1\%\]{top:-1%}
 .su-top-\[1\.75em\]{top:1.75em}
+.su-top-\[3px\]{top:3px}
 .su-top-\[50\%\]{top:50%}
+.su-top-\[7px\]{top:7px}
 .su-top-\[80px\]{top:80px}
+.su-top-\[9px\]{top:9px}
 .su-top-auto{top:auto}
 .\!su-z-\[1\]{z-index:1 !important}
 .su-z-0{z-index:0}
@@ -2325,7 +2352,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mb-\[-1\.75em\]{margin-bottom:-1.75em}
 .su-mb-\[-3px\]{margin-bottom:-3px}
 .su-mb-\[0px\]{margin-bottom:0px}
+.su-mb-\[13px\]{margin-bottom:13px}
+.su-mb-\[15px\]{margin-bottom:15px}
+.su-mb-\[20px\]{margin-bottom:20px}
 .su-mb-\[3\.2rem\]{margin-bottom:3.2rem}
+.su-mb-\[5px\]{margin-bottom:5px}
 .su-mb-auto{margin-bottom:auto}
 .su-ml-0{margin-left:0}
 .su-ml-05em{margin-left:0.5em}
@@ -2338,6 +2369,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-ml-8{margin-left:0.8rem}
 .su-ml-\[-\.5rem\]{margin-left:-.5rem}
 .su-ml-\[-3px\]{margin-left:-3px}
+.su-ml-\[-42px\]{margin-left:-42px}
 .su-ml-auto{margin-left:auto}
 .su-mr-0{margin-right:0}
 .su-mr-13{margin-right:1.3rem}
@@ -2384,9 +2416,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mt-\[-63px\]{margin-top:-63px}
 .su-mt-\[-6px\]{margin-top:-6px}
 .su-mt-\[1\.5rem\]{margin-top:1.5rem}
+.su-mt-\[15px\]{margin-top:15px}
 .su-mt-\[23\.65px\]{margin-top:23.65px}
 .su-mt-\[3\.2rem\]{margin-top:3.2rem}
 .su-mt-\[71px\]{margin-top:71px}
+.su-mt-\[9px\]{margin-top:9px}
 .su-mt-auto{margin-top:auto}
 .su-block{display:block}
 .su-inline-block{display:inline-block}
@@ -2417,16 +2451,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-0{height:0}
 .su-h-1{height:0.1rem}
 .su-h-2{height:0.2rem}
-.su-h-20{height:2rem}
 .su-h-21{height:2.1rem}
-.su-h-23{height:2.3rem}
 .su-h-28{height:2.8rem}
 .su-h-3{height:0.3rem}
 .su-h-32{height:3.2rem}
 .su-h-35{height:3.5rem}
 .su-h-4{height:0.4rem}
 .su-h-40{height:4rem}
-.su-h-42{height:4.2rem}
 .su-h-43{height:4.3rem}
 .su-h-44{height:4.4rem}
 .su-h-45{height:4.5rem}
@@ -2435,13 +2466,14 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-500{height:50rem}
 .su-h-6{height:0.6rem}
 .su-h-60{height:6rem}
-.su-h-70{height:7rem}
 .su-h-72{height:7.2rem}
 .su-h-9{height:0.9rem}
 .su-h-90{height:9rem}
 .su-h-\[101\%\]{height:101%}
+.su-h-\[150px\]{height:150px}
 .su-h-\[165px\]{height:165px}
 .su-h-\[18\.6rem\]{height:18.6rem}
+.su-h-\[200px\]{height:200px}
 .su-h-\[218px\]{height:218px}
 .su-h-\[224px\]{height:224px}
 .su-h-\[233px\]{height:233px}
@@ -2449,6 +2481,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-\[2px\]{height:2px}
 .su-h-\[300px\]{height:300px}
 .su-h-\[34\.2rem\]{height:34.2rem}
+.su-h-\[342px\]{height:342px}
+.su-h-\[4px\]{height:4px}
+.su-h-\[50px\]{height:50px}
 .su-h-\[56px\]{height:56px}
 .su-h-\[60\%\]{height:60%}
 .su-h-\[66px\]{height:66px}
@@ -2485,7 +2520,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-w-4{width:0.4rem}
 .su-w-40{width:4rem}
 .su-w-41{width:4.1rem}
-.su-w-42{width:4.2rem}
 .su-w-44{width:4.4rem}
 .su-w-5{width:0.5rem}
 .su-w-5\/6{width:83.333333%}
@@ -2499,12 +2533,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-w-\[10\%\]{width:10%}
 .su-w-\[100\%\]{width:100%}
 .su-w-\[103px\]{width:103px}
+.su-w-\[150px\]{width:150px}
 .su-w-\[16\.66\%\]{width:16.66%}
 .su-w-\[165px\]{width:165px}
+.su-w-\[200px\]{width:200px}
 .su-w-\[218px\]{width:218px}
 .su-w-\[22\.6rem\]{width:22.6rem}
 .su-w-\[224px\]{width:224px}
 .su-w-\[2px\]{width:2px}
+.su-w-\[50px\]{width:50px}
 .su-w-\[56px\]{width:56px}
 .su-w-\[73px\]{width:73px}
 .su-w-\[83\.333\%\]{width:83.333%}
@@ -2519,6 +2556,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-min-w-\[165px\]{min-width:165px}
 .su-min-w-\[218px\]{min-width:218px}
 .su-min-w-\[24\.9rem\]{min-width:24.9rem}
+.su-min-w-\[249px\]{min-width:249px}
 .su-min-w-\[56px\]{min-width:56px}
 .su-min-w-full{min-width:100%}
 .su-max-w-1500{max-width:150rem}
@@ -2556,6 +2594,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-translate-x-03em{--tw-translate-x:0.3em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-1em{--tw-translate-x:1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-\[-50\%\]{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-translate-x-\[42px\]{--tw-translate-x:42px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-0{--tw-translate-y:0;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-1{--tw-translate-y:0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-\[-110px\]{--tw-translate-y:-110px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -2565,6 +2604,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rotate-90{--tw-rotate:90deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-rotate-\[-90deg\]{--tw-rotate:-90deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-scale-110{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-transform{transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-cursor-pointer{cursor:pointer}
 .su-list-none{list-style-type:none}
 .su-grid-cols-1{grid-template-columns:repeat(1, minmax(0, 1fr))}
@@ -2628,10 +2668,20 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-\[0\.6rem\]{gap:0.6rem}
 .su-gap-\[1\.5rem\]{gap:1.5rem}
 .su-gap-\[1\.8rem\]{gap:1.8rem}
+.su-gap-\[10px\]{gap:10px}
+.su-gap-\[11px\]{gap:11px}
 .su-gap-\[18px\]{gap:18px}
+.su-gap-\[19px\]{gap:19px}
 .su-gap-\[2\.1rem\]{gap:2.1rem}
+.su-gap-\[20px\]{gap:20px}
+.su-gap-\[27px\]{gap:27px}
+.su-gap-\[2px\]{gap:2px}
+.su-gap-\[34px\]{gap:34px}
+.su-gap-\[5px\]{gap:5px}
 .su-gap-\[68px\]{gap:68px}
+.su-gap-\[6px\]{gap:6px}
 .su-gap-\[7px\]{gap:7px}
+.su-gap-\[9px\]{gap:9px}
 .su-gap-px{gap:1px}
 .su-gap-x-13{column-gap:1.3rem}
 .su-gap-x-16{column-gap:1.6rem}
@@ -2643,6 +2693,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-x-31{column-gap:3.1em}
 .su-gap-x-40{column-gap:4rem}
 .su-gap-x-\[0\.691rem\]{column-gap:0.691rem}
+.su-gap-x-\[13px\]{column-gap:13px}
 .su-gap-y-0{row-gap:0}
 .su-gap-y-11{row-gap:1.1rem}
 .su-gap-y-12{row-gap:1.2rem}
@@ -2676,6 +2727,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-border-l-2{border-left-width:2px}
 .su-border-r{border-right-width:1px}
 .su-border-t{border-top-width:1px}
+.su-border-solid{border-style:solid}
 .su-border-none{border-style:none}
 .su-border-black{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
 .su-border-black-10{--tw-border-opacity:1;border-color:rgb(234 234 234 / var(--tw-border-opacity))}
@@ -2724,6 +2776,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-to-digital-red-dark{--tw-gradient-to:#820000 var(--tw-gradient-to-position)}
 .su-to-digital-red-light{--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
 .su-to-olive{--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+.su-to-plum{--tw-gradient-to:#620059 var(--tw-gradient-to-position)}
 .su-to-50\%{--tw-gradient-to-position:50%}
 .su-bg-cover{background-size:cover}
 .su-bg-center{background-position:center}
@@ -2751,6 +2804,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-p-48{padding:4.8rem}
 .su-p-7{padding:0.7rem}
 .su-p-9{padding:0.9rem}
+.su-p-\[3px\]{padding:3px}
+.su-p-\[7px\]{padding:7px}
+.su-p-\[9px\]{padding:9px}
 .su-px-0{padding-left:0;padding-right:0}
 .su-px-20{padding-left:2rem;padding-right:2rem}
 .su-px-22{padding-left:2.2rem;padding-right:2.2rem}
@@ -2764,6 +2820,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-px-5{padding-left:0.5rem;padding-right:0.5rem}
 .su-px-50{padding-left:5rem;padding-right:5rem}
 .su-px-65{padding-left:6.5rem;padding-right:6.5rem}
+.su-px-\[20px\]{padding-left:20px;padding-right:20px}
 .su-py-0{padding-top:0;padding-bottom:0}
 .su-py-10{padding-top:1rem;padding-bottom:1rem}
 .su-py-15{padding-top:1.5rem;padding-bottom:1.5rem}
@@ -2813,6 +2870,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pl-39{padding-left:3.9rem}
 .su-pl-48{padding-left:4.8rem}
 .su-pl-50{padding-left:5rem}
+.su-pl-\[39px\]{padding-left:39px}
 .su-pl-\[calc\(16\.666\%\+10px\)\]{padding-left:calc(16.666% + 10px)}
 .su-pr-0{padding-right:0}
 .su-pr-10{padding-right:1rem}
@@ -2875,8 +2933,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-\[1\.5rem\]{font-size:1.5rem}
 .su-text-\[1\.8rem\]{font-size:1.8rem}
 .su-text-\[14px\]{font-size:14px}
+.su-text-\[16px\]{font-size:16px}
+.su-text-\[18px\]{font-size:18px}
+.su-text-\[19px\]{font-size:19px}
 .su-text-\[2\.0rem\]{font-size:2.0rem}
 .su-text-\[2\.4rem\]{font-size:2.4rem}
+.su-text-\[20px\]{font-size:20px}
+.su-text-\[21px\]{font-size:21px}
+.su-text-\[24px\]{font-size:24px}
+.su-text-\[28px\]{font-size:28px}
 .su-text-\[3\.5rem\]{font-size:3.5rem}
 .su-text-\[33px\]{font-size:33px}
 .su-text-\[35px\]{font-size:35px}
@@ -2902,10 +2967,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-leading-\[1\.6rem\]{line-height:1.6rem}
 .su-leading-\[119\.4\%\]{line-height:119.4%}
 .su-leading-\[119\.415\%\]{line-height:119.415%}
+.su-leading-\[120\%\]{line-height:120%}
 .su-leading-\[125\%\]{line-height:125%}
 .su-leading-\[125\.28\%\]{line-height:125.28%}
 .su-leading-\[130\%\]{line-height:130%}
 .su-leading-\[130\.245\%\]{line-height:130.245%}
+.su-leading-\[150\%\]{line-height:150%}
 .su-leading-\[16\.72px\]{line-height:16.72px}
 .su-leading-\[16px\]{line-height:16px}
 .su-leading-\[17\.5px\]{line-height:17.5px}
@@ -2950,6 +3017,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-leading-tight{line-height:1.1}
 .su-tracking-normal{letter-spacing:0em}
 .\!su-text-digital-red{--tw-text-opacity:1 !important;color:rgb(177 4 14 / var(--tw-text-opacity)) !important}
+.su-text-\[white\]{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .su-text-black{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
 .su-text-black-40{--tw-text-opacity:1;color:rgb(171 171 169 / var(--tw-text-opacity))}
 .su-text-black-50{--tw-text-opacity:1;color:rgb(151 150 148 / var(--tw-text-opacity))}
@@ -3678,11 +3746,14 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .before\:su--mt-25::before{content:var(--tw-content);margin-top:-2.5rem}
 .before\:su--mt-30::before{content:var(--tw-content);margin-top:-3rem}
 .before\:su-mr-6::before{content:var(--tw-content);margin-right:0.6rem}
+.before\:su-mr-\[6px\]::before{content:var(--tw-content);margin-right:6px}
+.before\:su-mt-\[-25px\]::before{content:var(--tw-content);margin-top:-25px}
 .before\:su-block::before{content:var(--tw-content);display:block}
 .before\:su-h-1::before{content:var(--tw-content);height:0.1rem}
 .before\:su-h-15::before{content:var(--tw-content);height:1.5rem}
 .before\:su-h-2::before{content:var(--tw-content);height:0.2rem}
 .before\:su-h-4::before{content:var(--tw-content);height:0.4rem}
+.before\:su-h-\[1px\]::before{content:var(--tw-content);height:1px}
 .before\:su-h-\[4\.5px\]::before{content:var(--tw-content);height:4.5px}
 .before\:su-h-full::before{content:var(--tw-content);height:100%}
 .before\:su-h-px::before{content:var(--tw-content);height:1px}
@@ -3991,9 +4062,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-mb-30{margin-bottom:3rem}
 .md\:su-mb-60{margin-bottom:6rem}
 .md\:su-mb-8{margin-bottom:0.8rem}
+.md\:su-mb-\[11px\]{margin-bottom:11px}
+.md\:su-mb-\[18px\]{margin-bottom:18px}
+.md\:su-mb-\[19px\]{margin-bottom:19px}
+.md\:su-mb-\[26px\]{margin-bottom:26px}
+.md\:su-mb-\[27px\]{margin-bottom:27px}
 .md\:su-mb-\[3px\]{margin-bottom:3px}
 .md\:su-mb-\[5\.9rem\]{margin-bottom:5.9rem}
 .md\:su-mb-\[6\.05px\]{margin-bottom:6.05px}
+.md\:su-mb-\[8px\]{margin-bottom:8px}
 .md\:su-ml-19{margin-left:1.9rem}
 .md\:su-ml-\[19px\]{margin-left:19px}
 .md\:su-ml-\[8\.333\%\]{margin-left:8.333%}
@@ -4010,6 +4087,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-mt-26{margin-top:2.6rem}
 .md\:su-mt-61{margin-top:6.1rem}
 .md\:su-mt-\[1\.9rem\]{margin-top:1.9rem}
+.md\:su-mt-\[12px\]{margin-top:12px}
+.md\:su-mt-\[26px\]{margin-top:26px}
 .md\:su-mt-\[4\.8rem\]{margin-top:4.8rem}
 .md\:su-mt-auto{margin-top:auto}
 .md\:su-block{display:block}
@@ -4029,6 +4108,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-max-h-\[168px\]{max-height:168px}
 .md\:su-max-h-\[6em\]{max-height:6em}
 .md\:su-min-h-\[38\.4rem\]{min-height:38.4rem}
+.md\:su-min-h-\[384px\]{min-height:384px}
 .md\:su-w-1\/3{width:33.333333%}
 .md\:su-w-3{width:0.3rem}
 .md\:su-w-30{width:3rem}
@@ -4050,6 +4130,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-w-auto{width:auto}
 .md\:su-min-w-\[170px\]{min-width:170px}
 .md\:su-min-w-\[17rem\]{min-width:17rem}
+.md\:su-min-w-\[249px\]{min-width:249px}
 .md\:su-min-w-\[257px\]{min-width:257px}
 .md\:su-max-w-\[168px\]{max-width:168px}
 .md\:su-max-w-\[482px\]{max-width:482px}
@@ -4086,8 +4167,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-gap-6{gap:0.6rem}
 .md\:su-gap-72{gap:7.2rem}
 .md\:su-gap-9{gap:0.9rem}
+.md\:su-gap-\[0px\]{gap:0px}
+.md\:su-gap-\[12px\]{gap:12px}
 .md\:su-gap-\[13px\]{gap:13px}
 .md\:su-gap-\[2\.5rem\]{gap:2.5rem}
+.md\:su-gap-\[36px\]{gap:36px}
+.md\:su-gap-\[48px\]{gap:48px}
+.md\:su-gap-\[72px\]{gap:72px}
 .md\:su-gap-x-20{column-gap:2rem}
 .md\:su-gap-x-24{column-gap:2.4rem}
 .md\:su-gap-x-27{column-gap:2.7rem}
@@ -4132,6 +4218,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pb-9{padding-bottom:0.9rem}
 .md\:su-pb-\[1\.3rem\]{padding-bottom:1.3rem}
 .md\:su-pb-\[10px\]{padding-bottom:10px}
+.md\:su-pb-\[13px\]{padding-bottom:13px}
 .md\:su-pb-\[14px\]{padding-bottom:14px}
 .md\:su-pb-\[16\.6rem\]{padding-bottom:16.6rem}
 .md\:su-pb-\[17\.7rem\]{padding-bottom:17.7rem}
@@ -4139,6 +4226,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pb-\[20\.05px\]{padding-bottom:20.05px}
 .md\:su-pb-\[6\.05px\]{padding-bottom:6.05px}
 .md\:su-pb-\[64px\]{padding-bottom:64px}
+.md\:su-pb-\[9px\]{padding-bottom:9px}
 .md\:su-pl-0{padding-left:0}
 .md\:su-pl-50{padding-left:5rem}
 .md\:su-pr-0{padding-right:0}
@@ -4170,8 +4258,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-text-\[1\.9rem\]{font-size:1.9rem}
 .md\:su-text-\[10rem\]{font-size:10rem}
 .md\:su-text-\[16px\]{font-size:16px}
+.md\:su-text-\[19px\]{font-size:19px}
+.md\:su-text-\[20px\]{font-size:20px}
+.md\:su-text-\[21px\]{font-size:21px}
+.md\:su-text-\[28px\]{font-size:28px}
 .md\:su-text-\[3\.6rem\]{font-size:3.6rem}
 .md\:su-text-\[35px\]{font-size:35px}
+.md\:su-text-\[36px\]{font-size:36px}
 .md\:su-text-\[4\.0rem\]{font-size:4.0rem}
 .md\:su-text-\[40px\]{font-size:40px}
 .md\:su-text-\[4rem\]{font-size:4rem}
@@ -4228,6 +4321,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .before\:md\:su-h-full::before{content:var(--tw-content);height:100%}
 .md\:before\:su-h-full::before{content:var(--tw-content);height:100%}
 .before\:md\:su-w-1::before{content:var(--tw-content);width:0.1rem}
+.before\:md\:su-w-\[1px\]::before{content:var(--tw-content);width:1px}
 .before\:md\:su-w-full::before{content:var(--tw-content);width:100%}
 .before\:md\:su-w-px::before{content:var(--tw-content);width:1px}
 .md\:before\:su-w-\[26\%\]::before{content:var(--tw-content);width:26%}
@@ -4276,7 +4370,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-mb-8{margin-bottom:0.8rem}
 .lg\:su-mb-9{margin-bottom:0.9rem}
 .lg\:su-mb-\[104px\]{margin-bottom:104px}
+.lg\:su-mb-\[12px\]{margin-bottom:12px}
+.lg\:su-mb-\[15px\]{margin-bottom:15px}
+.lg\:su-mb-\[19px\]{margin-bottom:19px}
 .lg\:su-mb-\[2\.25px\]{margin-bottom:2.25px}
+.lg\:su-mb-\[38px\]{margin-bottom:38px}
 .lg\:su-mb-\[4px\]{margin-bottom:4px}
 .lg\:su-ml-0{margin-left:0}
 .lg\:su-ml-26{margin-left:2.6rem}
@@ -4303,6 +4401,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-mt-\[-131px\]{margin-top:-131px}
 .lg\:su-mt-\[0px\]{margin-top:0px}
 .lg\:su-mt-\[19\.5px\]{margin-top:19.5px}
+.lg\:su-mt-\[29px\]{margin-top:29px}
 .lg\:su-block{display:block}
 .lg\:su-inline-block{display:inline-block}
 .lg\:su-flex{display:flex}
@@ -4313,9 +4412,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-h-9{height:0.9rem}
 .lg\:su-h-\[193px\]{height:193px}
 .lg\:su-h-\[292px\]{height:292px}
+.lg\:su-h-\[373px\]{height:373px}
 .lg\:su-h-\[378\.331px\]{height:378.331px}
 .lg\:su-h-\[4px\]{height:4px}
 .lg\:su-h-\[57\.2rem\]{height:57.2rem}
+.lg\:su-h-\[572px\]{height:572px}
 .lg\:su-h-\[764px\]{height:764px}
 .lg\:su-h-\[871\.33px\]{height:871.33px}
 .lg\:su-h-\[calc\(100\%\+15\.5rem\+1em\)\]{height:calc(100% + 15.5rem + 1em)}
@@ -4337,12 +4438,14 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-w-\[calc\(50\%-1\.9rem\)\]{width:calc(50% - 1.9rem)}
 .lg\:su-w-full{width:100%}
 .lg\:su-min-w-\[38\.2rem\]{min-width:38.2rem}
+.lg\:su-min-w-\[382px\]{min-width:382px}
 .lg\:su-max-w-\[185px\]{max-width:185px}
 .lg\:su-max-w-\[29\.2rem\]{max-width:29.2rem}
 .lg\:su-max-w-\[293px\]{max-width:293px}
 .lg\:su-max-w-\[296px\]{max-width:296px}
 .lg\:su-max-w-\[35\.9rem\]{max-width:35.9rem}
 .lg\:su-max-w-\[38\.2rem\]{max-width:38.2rem}
+.lg\:su-max-w-\[382px\]{max-width:382px}
 .lg\:su-max-w-\[63\.6rem\]{max-width:63.6rem}
 .lg\:su-max-w-\[633px\]{max-width:633px}
 .lg\:su-flex-1{flex:1 1 0%}
@@ -4375,9 +4478,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-gap-61{gap:6.1rem}
 .lg\:su-gap-9{gap:0.9rem}
 .lg\:su-gap-\[102px\]{gap:102px}
+.lg\:su-gap-\[12px\]{gap:12px}
+.lg\:su-gap-\[13px\]{gap:13px}
 .lg\:su-gap-\[160px\]{gap:160px}
 .lg\:su-gap-\[36px\]{gap:36px}
+.lg\:su-gap-\[48px\]{gap:48px}
 .lg\:su-gap-\[76px\]{gap:76px}
+.lg\:su-gap-\[9px\]{gap:9px}
 .lg\:su-gap-x-20{column-gap:2rem}
 .lg\:su-gap-x-27{column-gap:2.7rem}
 .lg\:su-gap-x-40{column-gap:4rem}
@@ -4395,6 +4502,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-py-30{padding-top:3rem;padding-bottom:3rem}
 .lg\:su-py-36{padding-top:3.6rem;padding-bottom:3.6rem}
 .lg\:su-py-61{padding-top:6.1rem;padding-bottom:6.1rem}
+.lg\:su-py-\[30px\]{padding-top:30px;padding-bottom:30px}
 .lg\:su-pb-0{padding-bottom:0}
 .lg\:su-pb-16{padding-bottom:1.6rem}
 .lg\:su-pb-27{padding-bottom:2.7rem}
@@ -4433,7 +4541,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-text-23{font-size:2.3rem}
 .lg\:su-text-24{font-size:2.4rem}
 .lg\:su-text-\[128px\]{font-size:128px}
+.lg\:su-text-\[16px\]{font-size:16px}
+.lg\:su-text-\[18px\]{font-size:18px}
 .lg\:su-text-\[2\.1rem\]{font-size:2.1rem}
+.lg\:su-text-\[20px\]{font-size:20px}
+.lg\:su-text-\[21px\]{font-size:21px}
+.lg\:su-text-\[23px\]{font-size:23px}
+.lg\:su-text-\[24px\]{font-size:24px}
 .lg\:su-text-\[32px\]{font-size:32px}
 .lg\:su-text-\[33px\]{font-size:33px}
 .lg\:su-text-\[4\.3rem\]{font-size:4.3rem}
@@ -4484,6 +4598,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:before\:su--mt-32::before{content:var(--tw-content);margin-top:-3.2rem}
 .lg\:before\:su--mt-38::before{content:var(--tw-content);margin-top:-3.8rem}
 .lg\:before\:su-mr-13::before{content:var(--tw-content);margin-right:1.3rem}
+.lg\:before\:su-mr-\[13px\]::before{content:var(--tw-content);margin-right:13px}
+.lg\:before\:su-mt-\[-38px\]::before{content:var(--tw-content);margin-top:-38px}
 .before\:lg\:su-h-full::before{content:var(--tw-content);height:100%}
 .lg\:before\:su-h-full::before{content:var(--tw-content);height:100%}
 .lg\:before\:su-h-px::before{content:var(--tw-content);height:1px}
@@ -4515,17 +4631,39 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\[\&\>\*\:last-child\]\:su-mb-0>*:last-child{margin-bottom:0}
 .\[\&\>\*\:last-child\]\:after\:su-content-\[\'\\u201D\'\]>*:last-child::after{--tw-content:'\u201D';content:var(--tw-content)}
 .\[\&\>\*\:last-child\]\:after\:su-content-\[\'\201D\'\]>*:last-child::after{--tw-content:'”';content:var(--tw-content)}
+.\[\&\>\*\]\:su-my-0>*{margin-top:0;margin-bottom:0}
+.\[\&\>\*\]\:su-mt-\[4px\]>*{margin-top:4px}
 .\[\&\>\*\]\:su-inline-block>*{display:inline-block}
 .\[\&\>\*\]\:su-h-23>*{height:2.3rem}
+.\[\&\>\*\]\:su-h-\[42px\]>*{height:42px}
 .\[\&\>\*\]\:su-w-24>*{width:2.4rem}
+.\[\&\>\*\]\:su-w-\[42px\]>*{width:42px}
+.\[\&\>\*\]\:su-w-full>*{width:100%}
 .\[\&\>\*\]\:su-translate-x-\[\.12em\]>*{--tw-translate-x:.12em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>\*\]\:su-translate-y-\[-\.08em\]>*{--tw-translate-y:-.08em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>\*\]\:su-rotate-\[-45deg\]>*{--tw-rotate:-45deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>\*\]\:su-justify-center>*{justify-content:center}
+.\[\&\>\*\]\:su-fill-transparent>*{fill:transparent}
 .\[\&\>\*\]\:su-stroke-current>*{stroke:currentColor}
 .\[\&\>\*\]\:su-stroke-digital-red>*{stroke:#B1040E}
+.\[\&\>\*\]\:su-font-sans>*{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif}
+.\[\&\>\*\]\:su-text-\[18px\]>*{font-size:18px}
+.\[\&\>\*\]\:su-text-\[19px\]>*{font-size:19px}
 .\[\&\>\*\]\:su-font-bold>*{font-weight:700}
+.\[\&\>\*\]\:su-font-normal>*{font-weight:400}
+.\[\&\>\*\]\:su-leading-\[125\%\]>*{line-height:125%}
+.\[\&\>\*\]\:su-leading-\[130\%\]>*{line-height:130%}
+.\[\&\>\*\]\:su-leading-\[22\.5px\]>*{line-height:22.5px}
+.\[\&\>\*\]\:su-leading-\[23\.75px\]>*{line-height:23.75px}
 :is(.su-dark .dark\:\[\&\>\*\]\:su-stroke-dark-mode-red>*){stroke:#EC0909}
+:is(.su-dark .\[\&\>\*\]\:dark\:su-text-white)>*{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+@media (min-width: 768px){
+.\[\&\>\*\]\:md\:su-mt-\[14px\]>*{margin-top:14px}
+.\[\&\>\*\]\:md\:su-text-\[19px\]>*{font-size:19px}
+.md\:\[\&\>\*\]\:su-text-\[19px\]>*{font-size:19px}
+.\[\&\>\*\]\:md\:su-leading-\[23\.75px\]>*{line-height:23.75px}}
+@media (min-width: 992px){
+.lg\:\[\&\>\*\]\:su-text-\[21px\]>*{font-size:21px}}
 .\[\&\>li\]\:su-m-0>li{margin:0}
 .\[\&\>p\]\:su-m-0>p{margin:0}
 .\[\&\>p\]\:\!su-mb-0>p{margin-bottom:0 !important}
@@ -4536,14 +4674,18 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\[\&\>svg\]\:su-mt-3>svg{margin-top:0.3rem}
 .\[\&\>svg\]\:su-h-40>svg{height:4rem}
 .\[\&\>svg\]\:su-h-43>svg{height:4.3rem}
+.\[\&\>svg\]\:su-h-\[40px\]>svg{height:40px}
 .\[\&\>svg\]\:su-w-40>svg{width:4rem}
 .\[\&\>svg\]\:su-w-41>svg{width:4.1rem}
+.\[\&\>svg\]\:su-w-\[40px\]>svg{width:40px}
 .\[\&\>svg\]\:su-translate-y-1>svg{--tw-translate-y:0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 @media (min-width: 768px){
 .md\:\[\&\>svg\]\:su--mt-2>svg{margin-top:-0.2rem}
 .\[\&\>svg\]\:md\:su-h-60>svg{height:6rem}
+.\[\&\>svg\]\:md\:su-h-\[60px\]>svg{height:60px}
 .md\:\[\&\>svg\]\:su-h-\[102px\]>svg{height:102px}
 .\[\&\>svg\]\:md\:su-w-60>svg{width:6rem}
+.\[\&\>svg\]\:md\:su-w-\[60px\]>svg{width:60px}
 .md\:\[\&\>svg\]\:su-w-\[97px\]>svg{width:97px}}
 @media (min-width: 992px){
 .lg\:\[\&\>svg\]\:su-mt-4>svg{margin-top:0.4rem}}

--- a/global/css/_global.css
+++ b/global/css/_global.css
@@ -1141,16 +1141,22 @@ Subscribe to Stanford Report Marketo form styles
 }
 
 /* Checkbox styles */
-.marketo-sr-subscribe-form.mktoForm .mktoCheckboxList {
+.marketo-sr-subscribe-form.mktoForm .mktoCheckboxList,
+.marketo-sr-subscribe-form.mktoForm .mktoRadioList {
   @apply su-grid su-grid-cols-[auto_1fr] su-gap-x-14 su-gap-y-24 su-mt-20 su-p-0;
 }
 
-.marketo-sr-subscribe-form.mktoForm .mktoCheckboxList label {
+.marketo-sr-subscribe-form.mktoForm .mktoCheckboxList label,
+.marketo-sr-subscribe-form.mktoForm .mktoRadioList label {
   @apply su-text-18 su-mt-01em su-leading-display su-cursor-pointer peer-hover:su-underline;
 }
 
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"] {
+.marketo-sr-subscribe-form.mktoForm input[type="checkbox"],
+.marketo-sr-subscribe-form.mktoForm input[type="radio"] {
   @apply su-w-auto su-text-digital-blue su-cursor-pointer hocus:su-ring-digital-blue-light/40 dark:hocus:su-ring-digital-blue-vivid/60 hocus:su-ring-4 su-border-black-50 dark:su-border-black-30 dark:hocus:su-border-digital-blue-light dark:su-bg-black-true dark:checked:su-bg-digital-blue su-border-2 su-rounded hocus:su-border-digital-blue checked:su-border-digital-blue-light dark:checked:su-border-digital-blue-light focus:su-ring-offset-0 focus:su-outline-none checked:hocus:su-bg-digital-blue-dark dark:checked:hocus:su-bg-digital-blue-vivid;
+}
+.marketo-sr-subscribe-form.mktoForm input[type="radio"] {
+  @apply su-rounded-full;
 }
 
 /* Marketo puts the asterisk before the label text(?) so


### PR DESCRIPTION
# Summary
- Style radio buttons on Marketo subscribe forms to look (mostly) like checkboxes

# Review By (Date)
- ASAP

# Criticality
- 5 - Only affects the [Subscribe](https://news.stanford.edu/subscribe) page and the new [Campaign Tracking](https://news.stanford.edu/obfuscated-campaign-tracker-1891) page, but we want to launch the Campaign Tracking page soon, and this needs to be in place before we do.

# Review Tasks

## How to test

1. Log in to Matrix so you can see the unpublished pages in the dev environment.
1. Verify my changes worked: Visit [the Campaign Tracker page in the dev environment](https://news.stanford.edu/developreport/campaign-tracker/_nocache), and confirm that the radio buttons look good at all breakpoints, and in both light and dark modes.
1. Verify I didn't introduce any regressions: Visit [the Subscribe page in the dev environment](https://news.stanford.edu/developreport/subscribe-to-stanford-report/_nocache), and confirm that it looks the same as [the live Subscribe page](https://news.stanford.edu/subscribe).

# Associated Issues and/or People
- [UCP-3414](https://stanfordits.atlassian.net/browse/UCP-3414)
- [UCP-3395](https://stanfordits.atlassian.net/browse/UCP-3395)


[UCP-3414]: https://stanfordits.atlassian.net/browse/UCP-3414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ