### PR TITLE
[UCP-3494] Interactive Photo Card titles dark mode

### DIFF
--- a/components/interactive-photo-card/Component.jsx
+++ b/components/interactive-photo-card/Component.jsx
@@ -61,7 +61,7 @@ export default function InteractivePhotoCard({
                   {eyebrow}
                 </div>
               )}
-              <h2 className="su-grow su-type-4 su-font-bold su-font-sans su-type su-rs-mb-0">
+              <h2 className="su-grow su-type-4 su-font-bold su-font-sans su-text-black dark:su-text-black su-rs-mb-0">
                 {title}
               </h2>
               <button

--- a/components/interactive-photo-card/manifest.json
+++ b/components/interactive-photo-card/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "interactive-photo-card",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "namespace": "stanford-components",
   "description": "2 side by side cards with 1 being a photo and 1 being a fact with the ability to flip the card over for additional information.",
   "displayName": "Interactive Photo Card",
@@ -45,17 +45,10 @@
             "title": "Image Alignment",
             "type": "string",
             "default": "right",
-            "enum": [
-              "left",
-              "right"
-            ]
+            "enum": ["left", "right"]
           }
         },
-        "required": [
-          "title",
-          "content",
-          "image"
-        ]
+        "required": ["title", "content", "image"]
       },
       "output": {
         "responseType": "html",

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -2066,6 +2066,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 }
 .su-bg-gradient-light-red-h-reverse{background-image:linear-gradient(to left, var(--tw-gradient-stops));--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
 :is(.su-dark .su-bg-gradient-light-red-h-reverse){background-image:linear-gradient(to top left, var(--tw-gradient-stops));--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:rgb(39 153 137 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #279989 var(--tw-gradient-via-position), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+.su-aspect-h-2{--tw-aspect-h:2}
+.su-aspect-w-1{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:1}
+.su-aspect-w-1 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
+.su-aspect-w-2{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:2}
+.su-aspect-w-2 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
+.su-aspect-w-3{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:3}
+.su-aspect-w-3 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
 .su-button{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;cursor:pointer;display:inline-block;border:none;font-weight:400;line-height:1;text-align:center;text-decoration:none;width:auto;transition:background-color 0.25s ease-in-out, color 0.25s ease-in-out;padding:1rem 2rem;background-color:#B1040E;color:#fff;}
 .su-button:active, .su-button:hover, .su-button:focus{text-decoration:underline}
 .su-button:hover, .su-button:focus{background-color:#2E2D29;color:#fff}
@@ -2133,6 +2140,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mt-2{margin-top:3.6rem}}
 @media (min-width: 1500px){
 .su-rs-mt-2{margin-top:3.8rem}}
+.su-rs-mb-2{margin-bottom:3rem;}
+@media (min-width: 768px){
+.su-rs-mb-2{margin-bottom:3.6rem}}
+@media (min-width: 1500px){
+.su-rs-mb-2{margin-bottom:3.8rem}}
 .su-rs-pl-2{padding-left:3rem;}
 @media (min-width: 768px){
 .su-rs-pl-2{padding-left:3.6rem}}
@@ -2143,6 +2155,16 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-py-2{padding-top:3.6rem;padding-bottom:3.6rem}}
 @media (min-width: 1500px){
 .su-rs-py-2{padding-top:3.8rem;padding-bottom:3.8rem}}
+.su-rs-mt-3{margin-top:3.2rem;}
+@media (min-width: 768px){
+.su-rs-mt-3{margin-top:4.5rem}}
+@media (min-width: 1500px){
+.su-rs-mt-3{margin-top:4.8rem}}
+.su-rs-mb-3{margin-bottom:3.2rem;}
+@media (min-width: 768px){
+.su-rs-mb-3{margin-bottom:4.5rem}}
+@media (min-width: 1500px){
+.su-rs-mb-3{margin-bottom:4.8rem}}
 .su-rs-py-3{padding-top:3.2rem;padding-bottom:3.2rem;}
 @media (min-width: 768px){
 .su-rs-py-3{padding-top:4.5rem;padding-bottom:4.5rem}}
@@ -2213,6 +2235,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-pt-6{padding-top:9rem}}
 @media (min-width: 1500px){
 .su-rs-pt-6{padding-top:9.5rem}}
+.su-rs-mb-6{margin-bottom:4.5rem;}
+@media (min-width: 768px){
+.su-rs-mb-6{margin-bottom:9rem}}
+@media (min-width: 1500px){
+.su-rs-mb-6{margin-bottom:9.5rem}}
 .su-rs-py-6{padding-top:4.5rem;padding-bottom:4.5rem;}
 @media (min-width: 768px){
 .su-rs-py-6{padding-top:9rem;padding-bottom:9rem}}
@@ -2233,11 +2260,21 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-py-7{padding-top:10.8rem;padding-bottom:10.8rem}}
 @media (min-width: 1500px){
 .su-rs-py-7{padding-top:11.4rem;padding-bottom:11.4rem}}
+.su-rs-mt-8{margin-top:6rem;}
+@media (min-width: 768px){
+.su-rs-mt-8{margin-top:12.6rem}}
+@media (min-width: 1500px){
+.su-rs-mt-8{margin-top:13.3rem}}
 .su-rs-pt-8{padding-top:6rem;}
 @media (min-width: 768px){
 .su-rs-pt-8{padding-top:12.6rem}}
 @media (min-width: 1500px){
 .su-rs-pt-8{padding-top:13.3rem}}
+.su-rs-mb-8{margin-bottom:6rem;}
+@media (min-width: 768px){
+.su-rs-mb-8{margin-bottom:12.6rem}}
+@media (min-width: 1500px){
+.su-rs-mb-8{margin-bottom:13.3rem}}
 .su-rs-pb-8{padding-bottom:6rem;}
 @media (min-width: 768px){
 .su-rs-pb-8{padding-bottom:12.6rem}}
@@ -2248,6 +2285,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-py-8{padding-top:12.6rem;padding-bottom:12.6rem}}
 @media (min-width: 1500px){
 .su-rs-py-8{padding-top:13.3rem;padding-bottom:13.3rem}}
+.su-rs-mt-9{margin-top:7rem;}
+@media (min-width: 768px){
+.su-rs-mt-9{margin-top:16.2rem}}
+@media (min-width: 1500px){
+.su-rs-mt-9{margin-top:17.1rem}}
 .su-rs-pt-9{padding-top:7rem;}
 @media (min-width: 768px){
 .su-rs-pt-9{padding-top:16.2rem}}
@@ -2268,6 +2310,16 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-py-9{padding-top:16.2rem;padding-bottom:16.2rem}}
 @media (min-width: 1500px){
 .su-rs-py-9{padding-top:17.1rem;padding-bottom:17.1rem}}
+.su-rs-mt-10{margin-top:8rem;}
+@media (min-width: 768px){
+.su-rs-mt-10{margin-top:21.6rem}}
+@media (min-width: 1500px){
+.su-rs-mt-10{margin-top:22.8rem}}
+.su-rs-mb-10{margin-bottom:8rem;}
+@media (min-width: 768px){
+.su-rs-mb-10{margin-bottom:21.6rem}}
+@media (min-width: 1500px){
+.su-rs-mb-10{margin-bottom:22.8rem}}
 .su-rs-py-10{padding-top:8rem;padding-bottom:8rem;}
 @media (min-width: 768px){
 .su-rs-py-10{padding-top:21.6rem;padding-bottom:21.6rem}}
@@ -2331,6 +2383,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\!su-absolute{position:absolute !important}
 .su-absolute{position:absolute}
 .su-relative{position:relative}
+.su-inset-0{inset:0}
 .su--left-80{left:-8rem}
 .su-bottom-0{bottom:0}
 .su-bottom-13{bottom:1.3rem}
@@ -2367,6 +2420,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-top-2{top:0.2rem}
 .su-top-3{top:0.3rem}
 .su-top-43{top:4.3rem}
+.su-top-45{top:4.5rem}
 .su-top-5{top:0.5rem}
 .su-top-7{top:0.7rem}
 .su-top-72{top:7.2rem}
@@ -2431,7 +2485,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su--ml-44{margin-left:-4.4rem}
 .su--ml-5{margin-left:-0.5rem}
 .su--mt-2{margin-top:-0.2rem}
+.su--mt-50{margin-top:-5rem}
 .su-mb-0{margin-bottom:0}
+.su-mb-02em{margin-bottom:0.2em}
 .su-mb-10{margin-bottom:1rem}
 .su-mb-11{margin-bottom:1.1rem}
 .su-mb-12{margin-bottom:1.2rem}
@@ -2464,6 +2520,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mb-\[3\.2rem\]{margin-bottom:3.2rem}
 .su-mb-auto{margin-bottom:auto}
 .su-ml-0{margin-left:0}
+.su-ml-04em{margin-left:0.4em}
 .su-ml-05em{margin-left:0.5em}
 .su-ml-1{margin-left:0.1rem}
 .su-ml-13{margin-left:1.3rem}
@@ -2471,11 +2528,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-ml-26{margin-left:2.6rem}
 .su-ml-38{margin-left:3.8rem}
 .su-ml-4{margin-left:0.4rem}
+.su-ml-5{margin-left:0.5rem}
 .su-ml-8{margin-left:0.8rem}
 .su-ml-\[-\.5rem\]{margin-left:-.5rem}
 .su-ml-\[-3px\]{margin-left:-3px}
 .su-ml-auto{margin-left:auto}
 .su-mr-0{margin-right:0}
+.su-mr-02em{margin-right:0.2em}
 .su-mr-13{margin-right:1.3rem}
 .su-mr-19{margin-right:1.9rem}
 .su-mr-2{margin-right:0.2rem}
@@ -2571,6 +2630,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-500{height:50rem}
 .su-h-6{height:0.6rem}
 .su-h-60{height:6rem}
+.su-h-70{height:7rem}
 .su-h-72{height:7.2rem}
 .su-h-9{height:0.9rem}
 .su-h-90{height:9rem}
@@ -2608,10 +2668,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-w-1{width:0.1rem}
 .su-w-1\/2{width:50%}
 .su-w-100{width:10rem}
+.su-w-180{width:18rem}
 .su-w-2{width:0.2rem}
 .su-w-20{width:2rem}
 .su-w-22{width:2.2rem}
-.su-w-23{width:2.3rem}
 .su-w-24{width:2.4rem}
 .su-w-28{width:2.8rem}
 .su-w-3{width:0.3rem}
@@ -2652,6 +2712,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-w-fit{width:fit-content}
 .su-w-full{width:100%}
 .su-w-screen{width:100vw}
+.su-min-w-100{min-width:10rem}
 .su-min-w-160{min-width:16rem}
 .su-min-w-\[165px\]{min-width:165px}
 .su-min-w-\[218px\]{min-width:218px}
@@ -2673,11 +2734,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-max-w-\[231px\]{max-width:231px}
 .su-max-w-\[33rem\]{max-width:33rem}
 .su-max-w-\[482px\]{max-width:482px}
+.su-max-w-\[55rem\]{max-width:55rem}
 .su-max-w-\[63\.3rem\]{max-width:63.3rem}
 .su-max-w-\[633px\]{max-width:633px}
 .su-max-w-\[71\.9rem\]{max-width:71.9rem}
 .su-max-w-full{max-width:100%}
 .su-max-w-none{max-width:none}
+.su-max-w-prose-wide{max-width:75ch}
 .su-flex-1{flex:1 1 0%}
 .su-flex-auto{flex:1 1 auto}
 .su-flex-shrink-0{flex-shrink:0}
@@ -2718,6 +2781,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-grid-rows-2{grid-template-rows:repeat(2, minmax(0, 1fr))}
 .su-flex-row{flex-direction:row}
 .su-flex-col{flex-direction:column}
+.su-flex-col-reverse{flex-direction:column-reverse}
 .su-flex-wrap{flex-wrap:wrap}
 .su-flex-nowrap{flex-wrap:nowrap}
 .su-place-content-between{place-content:space-between}
@@ -2807,6 +2871,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-overflow-x-scroll{overflow-x:scroll}
 .su-text-ellipsis{text-overflow:ellipsis}
 .su-whitespace-nowrap{white-space:nowrap}
+.su-whitespace-pre-line{white-space:pre-line}
 .su-break-words{overflow-wrap:break-word}
 .su-rounded{border-radius:0.3rem}
 .su-rounded-\[100px\]{border-radius:100px}
@@ -2817,6 +2882,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-border{border-width:1px}
 .su-border-2{border-width:2px}
 .su-border-3{border-width:3px}
+.su-border-\[2rem\]{border-width:2rem}
 .su-border-b{border-bottom-width:1px}
 .su-border-b-2{border-bottom-width:2px}
 .su-border-b-4{border-bottom-width:4px}
@@ -2831,6 +2897,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-border-black-30{--tw-border-opacity:1;border-color:rgb(192 192 191 / var(--tw-border-opacity))}
 .su-border-black-30\/30{border-color:rgb(192 192 191 / 0.3)}
 .su-border-black-60{--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity))}
+.su-border-black-true{--tw-border-opacity:1;border-color:rgb(0 0 0 / var(--tw-border-opacity))}
 .su-border-dark-mode-red{--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
 .su-border-digital-blue{--tw-border-opacity:1;border-color:rgb(0 108 184 / var(--tw-border-opacity))}
 .su-border-digital-blue-light{--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity))}
@@ -2862,6 +2929,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bg-gradient-to-l{background-image:linear-gradient(to left, var(--tw-gradient-stops))}
 .su-bg-gradient-to-r{background-image:linear-gradient(to right, var(--tw-gradient-stops))}
 .su-bg-gradient-to-t{background-image:linear-gradient(to top, var(--tw-gradient-stops))}
+.su-from-black-true{--tw-gradient-from:#000000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-digital-red{--tw-gradient-from:#B1040E var(--tw-gradient-from-position);--tw-gradient-to:rgb(177 4 14 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-digital-red-dark{--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-digital-red-light{--tw-gradient-from:#E50808 var(--tw-gradient-from-position);--tw-gradient-to:rgb(229 8 8 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
@@ -2888,9 +2956,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-object-scale-down{object-fit:scale-down}
 .su-object-\[left_center\]{object-position:left center}
 .su-object-\[right_center\]{object-position:right center}
+.su-object-bottom{object-position:bottom}
 .su-object-center{object-position:center}
+.su-object-top{object-position:top}
 .su-p-0{padding:0}
 .su-p-10{padding:1rem}
+.su-p-11{padding:1.1rem}
 .su-p-12{padding:1.2rem}
 .su-p-14{padding:1.4rem}
 .su-p-15{padding:1.5rem}
@@ -2917,6 +2988,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-py-0{padding-top:0;padding-bottom:0}
 .su-py-10{padding-top:1rem;padding-bottom:1rem}
 .su-py-15{padding-top:1.5rem;padding-bottom:1.5rem}
+.su-py-17{padding-top:1.7rem;padding-bottom:1.7rem}
 .su-py-20{padding-top:2rem;padding-bottom:2rem}
 .su-py-26{padding-top:2.6rem;padding-bottom:2.6rem}
 .su-py-30{padding-top:3rem;padding-bottom:3rem}
@@ -2949,8 +3021,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pb-9{padding-bottom:0.9rem}
 .su-pb-\[1\.1rem\]{padding-bottom:1.1rem}
 .su-pb-\[11rem\]{padding-bottom:11rem}
+.su-pb-\[13\.9rem\]{padding-bottom:13.9rem}
 .su-pb-\[171px\]{padding-bottom:171px}
 .su-pb-\[1rem\]{padding-bottom:1rem}
+.su-pb-\[20px\]{padding-bottom:20px}
 .su-pb-\[56\.25\%\]{padding-bottom:56.25%}
 .su-pl-0{padding-left:0}
 .su-pl-13{padding-left:1.3rem}
@@ -2997,6 +3071,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pt-\[\.9rem\]{padding-top:.9rem}
 .su-pt-\[11\.4rem\]{padding-top:11.4rem}
 .su-pt-\[115px\]{padding-top:115px}
+.su-pt-\[20px\]{padding-top:20px}
 .su-pt-\[249px\]{padding-top:249px}
 .su-text-left{text-align:left}
 .su-text-center{text-align:center}
@@ -3021,6 +3096,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-25{font-size:2.5rem}
 .su-text-26{font-size:2.6rem}
 .su-text-28{font-size:2.8rem}
+.su-text-\[0\.75em\]{font-size:0.75em}
+.su-text-\[0\.9em\]{font-size:0.9em}
 .su-text-\[1\.433rem\]{font-size:1.433rem}
 .su-text-\[1\.4rem\]{font-size:1.4rem}
 .su-text-\[1\.5rem\]{font-size:1.5rem}
@@ -3079,6 +3156,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-leading-\[21\.6px\]{line-height:21.6px}
 .su-leading-\[21px\]{line-height:21px}
 .su-leading-\[22\.5px\]{line-height:22.5px}
+.su-leading-\[22px\]{line-height:22px}
 .su-leading-\[23\.4px\]{line-height:23.4px}
 .su-leading-\[23\.75px\]{line-height:23.75px}
 .su-leading-\[23\.88px\]{line-height:23.88px}
@@ -3109,6 +3187,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-black-60{--tw-text-opacity:1;color:rgb(118 118 116 / var(--tw-text-opacity))}
 .su-text-black-70{--tw-text-opacity:1;color:rgb(109 108 105 / var(--tw-text-opacity))}
 .su-text-black-90{--tw-text-opacity:1;color:rgb(67 66 62 / var(--tw-text-opacity))}
+.su-text-black-true{--tw-text-opacity:1;color:rgb(0 0 0 / var(--tw-text-opacity))}
 .su-text-dark-mode-red{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .su-text-digital-blue{--tw-text-opacity:1;color:rgb(0 108 184 / var(--tw-text-opacity))}
 .su-text-digital-blue-vivid{--tw-text-opacity:1;color:rgb(5 151 255 / var(--tw-text-opacity))}
@@ -3119,6 +3198,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-white{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .su-underline{text-decoration-line:underline}
 .su-no-underline{text-decoration-line:none}
+.su-decoration-dark-mode-red{text-decoration-color:#EC0909}
+.su-decoration-\[3px\]{text-decoration-thickness:3px}
+.su-underline-offset-4{text-underline-offset:4px}
 .su-opacity-0{opacity:0}
 .su-opacity-100{opacity:1}
 .su-opacity-25{opacity:0.25}
@@ -3130,18 +3212,21 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-shadow-\[0px_3px_6px_0px_rgba\(0\,0\,0\,0\.1\)\]{--tw-shadow:0px 3px 6px 0px rgba(0,0,0,0.1);--tw-shadow-colored:0px 3px 6px 0px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 .su-shadow-\[0px_4px_7px_0px_rgba\(0\,0\,0\,0\.15\)\]{--tw-shadow:0px 4px 7px 0px rgba(0,0,0,0.15);--tw-shadow-colored:0px 4px 7px 0px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 .su-shadow-\[inset_0_0_0_2px_rgba\(177\,4\,14\,1\)\]{--tw-shadow:inset 0 0 0 2px rgba(177,4,14,1);--tw-shadow-colored:inset 0 0 0 2px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
+.su-shadow-inner{--tw-shadow:inset 0 2px 4px 0 rgb(0 0 0 / 0.05);--tw-shadow-colored:inset 0 2px 4px 0 var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 .su-shadow-lg{--tw-shadow:0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);--tw-shadow-colored:0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 .su-shadow-black{--tw-shadow-color:#2E2D29;--tw-shadow:var(--tw-shadow-colored)}
 .su-shadow-black-60{--tw-shadow-color:#767674;--tw-shadow:var(--tw-shadow-colored)}
 .su-shadow-black-60\/50{--tw-shadow-color:rgb(118 118 116 / 0.5);--tw-shadow:var(--tw-shadow-colored)}
 .su-shadow-white{--tw-shadow-color:#fff;--tw-shadow:var(--tw-shadow-colored)}
 .su-ring-digital-blue-vivid{--tw-ring-opacity:1;--tw-ring-color:rgb(5 151 255 / var(--tw-ring-opacity))}
+.su-ring-white{--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
 .su-drop-shadow-\[0px_14px_28px_rgba\(0\,0\,0\,0\.20\)\]{--tw-drop-shadow:drop-shadow(0px 14px 28px rgba(0,0,0,0.20));filter:var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow)}
 .su-transition{transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .su-transition-all{transition-property:all;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .su-transition-colors{transition-property:color, background-color, border-color, text-decoration-color, fill, stroke;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .su-transition-shadow{transition-property:box-shadow;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .su-transition-transform{transition-property:transform;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
+.su-duration-100{transition-duration:100ms}
 .su-duration-1000{transition-duration:1000ms}
 .su-ease-in-out{transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1)}
 .su-will-change-transform{will-change:transform}
@@ -3721,6 +3806,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\*\:su-basefont-19 > *{font-size:1.8rem}}
 @media (min-width: 1500px){
 .\*\:su-basefont-19 > *{font-size:1.9rem}}
+@media (min-width: 576px){
+.sm\:su-aspect-h-4{--tw-aspect-h:4}
+.sm\:su-aspect-w-3{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:3}
+.sm\:su-aspect-w-3 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}}
 @media (min-width: 768px){
 .md\:su-rs-py-6{padding-top:4.5rem;padding-bottom:4.5rem;}
 @media (min-width: 768px){
@@ -3748,6 +3837,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 @media (min-width: 1500px){
 .md\:su-basefont-23{font-size:2.3rem}}}
 @media (min-width: 992px){
+.lg\:su-aspect-h-2{--tw-aspect-h:2}
 .lg\:su-rs-py-5{padding-top:3.8rem;padding-bottom:3.8rem;}
 @media (min-width: 768px){
 .lg\:su-rs-py-5{padding-top:7.2rem;padding-bottom:7.2rem}}
@@ -3765,6 +3855,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 @media (min-width: 1500px){
 .xl\:su-rs-mb-9{margin-bottom:17.1rem}}}
 @media (min-width: 1500px){
+.\32xl\:su-aspect-h-1{--tw-aspect-h:1}
+.\32xl\:su-aspect-w-2{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:2}
+.\32xl\:su-aspect-w-2 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
 .\32xl\:su-type-3{font-size:1.52em;letter-spacing:-0.014em;}
 @media (min-width: 768px){
 .\32xl\:su-type-3{font-size:1.73em}}
@@ -3892,6 +3985,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\*\:last\:su-mb-0:last-child > *{margin-bottom:0}
 .last\:\*\:su-mb-0 > *:last-child{margin-bottom:0}
 .focus-within\:su-shadow-md:focus-within{--tw-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);--tw-shadow-colored:0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
+.hover\:su-border-black-40:hover{--tw-border-opacity:1;border-color:rgb(171 171 169 / var(--tw-border-opacity))}
 .hover\:su-border-black-70:hover{--tw-border-opacity:1;border-color:rgb(109 108 105 / var(--tw-border-opacity))}
 .hover\:su-border-digital-red:hover{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
 .hover\:su-bg-black:hover{--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
@@ -3937,11 +4031,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .hocus\:su-bg-black:hover{--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
 .hocus\:su-bg-digital-green-bright:hover{--tw-bg-opacity:1;background-color:rgb(0 155 118 / var(--tw-bg-opacity))}
 .hocus\:su-bg-digital-red:hover{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
+.hocus\:su-bg-none:hover{background-image:none}
 .hocus\:su-text-black:hover{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
 .hocus\:su-text-digital-red:hover{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .hocus\:su-text-white:hover{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .hocus\:su-underline:hover{text-decoration-line:underline}
 .hocus\:su-no-underline:hover{text-decoration-line:none}
+.hocus\:su-decoration-white:hover{text-decoration-color:#fff}
 .hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(177\2c 4\2c 14\2c 1\)\]:hover{--tw-shadow:inset 0 0 0 3px rgba(177,4,14,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 .hocus\:su-border-black:focus{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
 .hocus\:su-border-digital-blue-vivid:focus{--tw-border-opacity:1;border-color:rgb(5 151 255 / var(--tw-border-opacity))}
@@ -3951,11 +4047,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .hocus\:su-bg-black:focus{--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
 .hocus\:su-bg-digital-green-bright:focus{--tw-bg-opacity:1;background-color:rgb(0 155 118 / var(--tw-bg-opacity))}
 .hocus\:su-bg-digital-red:focus{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
+.hocus\:su-bg-none:focus{background-image:none}
 .hocus\:su-text-black:focus{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
 .hocus\:su-text-digital-red:focus{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .hocus\:su-text-white:focus{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .hocus\:su-underline:focus{text-decoration-line:underline}
 .hocus\:su-no-underline:focus{text-decoration-line:none}
+.hocus\:su-decoration-white:focus{text-decoration-color:#fff}
 .hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(177\2c 4\2c 14\2c 1\)\]:focus{--tw-shadow:inset 0 0 0 3px rgba(177,4,14,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 .su-group:focus .group-hocus\:su--translate-y-01em{--tw-translate-y:-0.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus .group-hocus\:su--translate-y-02em{--tw-translate-y:-0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -3963,6 +4061,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-group:focus .group-hocus\:su-translate-x-02em{--tw-translate-x:0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus .group-hocus\:su-translate-x-\[\.1em\]{--tw-translate-x:.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus .group-hocus\:su-translate-x-\[1\.1em\]{--tw-translate-x:1.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-group:focus .group-hocus\:su-translate-y-02em{--tw-translate-y:0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus .group-hocus\:su-translate-y-\[-\.1em\]{--tw-translate-y:-.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus .group-hocus\:su-text-digital-red{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .su-group:focus .group-hocus\:su-text-white{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
@@ -3973,6 +4072,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-group:hover .group-hocus\:su-translate-x-02em{--tw-translate-x:0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:hover .group-hocus\:su-translate-x-\[\.1em\]{--tw-translate-x:.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:hover .group-hocus\:su-translate-x-\[1\.1em\]{--tw-translate-x:1.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-group:hover .group-hocus\:su-translate-y-02em{--tw-translate-y:0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:hover .group-hocus\:su-translate-y-\[-\.1em\]{--tw-translate-y:-.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:hover .group-hocus\:su-text-digital-red{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .su-group:hover .group-hocus\:su-text-white{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
@@ -4077,6 +4177,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 :is(.su-dark .hocus\:dark\:su-text-dark-mode-red):hover{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 :is(.su-dark .dark\:hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(236\2c 9\2c 9\2c 1\)\]:hover){--tw-shadow:inset 0 0 0 3px rgba(236,9,9,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 :is(.su-dark .dark\:hocus\:su-ring-1:hover){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
+:is(.su-dark .dark\:hocus\:su-ring-2:hover){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
 :is(.su-dark .dark\:hocus\:su-ring-white:hover){--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
 :is(.su-dark .dark\:hocus\:su-border-dark-mode-red:focus){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
 :is(.su-dark .dark\:hocus\:su-border-digital-blue-light\/80:focus){border-color:rgb(133 204 255 / 0.8)}
@@ -4087,9 +4188,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 :is(.su-dark .hocus\:dark\:su-text-dark-mode-red):focus{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 :is(.su-dark .dark\:hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(236\2c 9\2c 9\2c 1\)\]:focus){--tw-shadow:inset 0 0 0 3px rgba(236,9,9,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 :is(.su-dark .dark\:hocus\:su-ring-1:focus){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
+:is(.su-dark .dark\:hocus\:su-ring-2:focus){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
 :is(.su-dark .dark\:hocus\:su-ring-white:focus){--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
 :is(.su-dark .su-group:focus .dark\:group-hocus\:su-text-dark-mode-red){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .su-group:focus .dark\:group-hocus\:su-text-white){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 :is(.su-dark .su-group:hover .dark\:group-hocus\:su-text-dark-mode-red){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .su-group:hover .dark\:group-hocus\:su-text-white){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 :is(.su-dark .su-group:focus-within .dark\:group-hocus-within\:su-text-digital-red-light){--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 :is(.su-dark .su-group:hover .dark\:group-hocus-within\:su-text-digital-red-light){--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 @media (min-width: 576px){
@@ -4105,6 +4209,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .sm\:su-mt-45{margin-top:4.5rem}
 .sm\:su-mt-\[-85px\]{margin-top:-85px}
 .sm\:su-h-500{height:50rem}
+.sm\:su-w-1\/3{width:33.333333%}
 .sm\:su-w-3\/4{width:75%}
 .sm\:su-w-\[25\%\]{width:25%}
 .sm\:su-translate-y-\[-130px\]{--tw-translate-y:-130px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -4112,6 +4217,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .sm\:su-gap-15{gap:1.5rem}
 .sm\:su-gap-40{gap:4rem}
 .sm\:su-overflow-visible{overflow:visible}
+.sm\:su-py-\[6\.8rem\]{padding-top:6.8rem;padding-bottom:6.8rem}
 .sm\:su-pl-20{padding-left:2rem}
 .sm\:su-pr-0{padding-right:0}
 .sm\:su-pr-20{padding-right:2rem}
@@ -4129,6 +4235,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-bottom-\[12\.3rem\]{bottom:12.3rem}
 .md\:su-left-27{left:2.7rem}
 .md\:su-right-48{right:4.8rem}
+.md\:su-top-06em{top:0.6em}
 .md\:su-top-72{top:7.2rem}
 .md\:su-top-\[75px\]{top:75px}
 .md\:su-top-auto{top:auto}
@@ -4161,11 +4268,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-mb-\[5\.9rem\]{margin-bottom:5.9rem}
 .md\:su-mb-\[6\.05px\]{margin-bottom:6.05px}
 .md\:su-ml-19{margin-left:1.9rem}
+.md\:su-ml-\[19px\]{margin-left:19px}
 .md\:su-ml-\[8\.333\%\]{margin-left:8.333%}
 .md\:su-mr-0{margin-right:0}
 .md\:su-mr-13{margin-right:1.3rem}
 .md\:su-mr-25{margin-right:2.5rem}
 .md\:su-mr-4{margin-right:0.4rem}
+.md\:su-mr-\[13px\]{margin-right:13px}
 .md\:su-mr-\[4px\]{margin-right:4px}
 .md\:su-mt-0{margin-top:0}
 .md\:su-mt-10{margin-top:1rem}
@@ -4300,8 +4409,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pb-\[1\.3rem\]{padding-bottom:1.3rem}
 .md\:su-pb-\[10px\]{padding-bottom:10px}
 .md\:su-pb-\[14px\]{padding-bottom:14px}
+.md\:su-pb-\[16\.6rem\]{padding-bottom:16.6rem}
 .md\:su-pb-\[17\.7rem\]{padding-bottom:17.7rem}
 .md\:su-pb-\[1px\]{padding-bottom:1px}
+.md\:su-pb-\[20\.05px\]{padding-bottom:20.05px}
 .md\:su-pb-\[6\.05px\]{padding-bottom:6.05px}
 .md\:su-pb-\[64px\]{padding-bottom:64px}
 .md\:su-pl-0{padding-left:0}
@@ -4318,6 +4429,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pt-45{padding-top:4.5rem}
 .md\:su-pt-\[159px\]{padding-top:159px}
 .md\:su-pt-\[167px\]{padding-top:167px}
+.md\:su-pt-\[21px\]{padding-top:21px}
 .md\:su-text-left{text-align:left}
 .md\:su-text-center{text-align:center}
 .md\:su-text-right{text-align:right}
@@ -4335,6 +4447,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-text-\[1\.9rem\]{font-size:1.9rem}
 .md\:su-text-\[10rem\]{font-size:10rem}
 .md\:su-text-\[16px\]{font-size:16px}
+.md\:su-text-\[2\.9rem\]{font-size:2.9rem}
 .md\:su-text-\[3\.3rem\]{font-size:3.3rem}
 .md\:su-text-\[3\.6rem\]{font-size:3.6rem}
 .md\:su-text-\[35px\]{font-size:35px}
@@ -4449,11 +4562,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-ml-38{margin-left:3.8rem}
 .lg\:su-ml-\[-10\%\]{margin-left:-10%}
 .lg\:su-ml-\[-2rem\]{margin-left:-2rem}
+.lg\:su-ml-\[26px\]{margin-left:26px}
 .lg\:su-ml-auto{margin-left:auto}
 .lg\:su-mr-0{margin-right:0}
 .lg\:su-mr-19{margin-right:1.9rem}
 .lg\:su-mr-36{margin-right:3.6rem}
 .lg\:su-mr-\[2\%\]{margin-right:2%}
+.lg\:su-mr-\[36px\]{margin-right:36px}
 .lg\:su-mt-0{margin-top:0}
 .lg\:su-mt-162{margin-top:16.2rem}
 .lg\:su-mt-19{margin-top:1.9rem}
@@ -4509,6 +4624,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-max-w-\[296px\]{max-width:296px}
 .lg\:su-max-w-\[35\.9rem\]{max-width:35.9rem}
 .lg\:su-max-w-\[38\.2rem\]{max-width:38.2rem}
+.lg\:su-max-w-\[50\%\]{max-width:50%}
 .lg\:su-max-w-\[63\.6rem\]{max-width:63.6rem}
 .lg\:su-max-w-\[633px\]{max-width:633px}
 .lg\:su-flex-1{flex:1 1 0%}
@@ -4556,6 +4672,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-self-start{align-self:flex-start}
 .lg\:su-border-b-transparent{border-bottom-color:transparent}
 .lg\:su-bg-white{--tw-bg-opacity:1;background-color:rgb(255 255 255 / var(--tw-bg-opacity))}
+.lg\:su-bg-gradient-to-l{background-image:linear-gradient(to left, var(--tw-gradient-stops))}
+.lg\:su-bg-gradient-to-r{background-image:linear-gradient(to right, var(--tw-gradient-stops))}
 .lg\:su-p-0{padding:0}
 .lg\:su-p-14{padding:1.4rem}
 .lg\:su-p-48{padding:4.8rem}
@@ -4565,10 +4683,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-py-36{padding-top:3.6rem;padding-bottom:3.6rem}
 .lg\:su-py-61{padding-top:6.1rem;padding-bottom:6.1rem}
 .lg\:su-pb-0{padding-bottom:0}
+.lg\:su-pb-16{padding-bottom:1.6rem}
 .lg\:su-pb-27{padding-bottom:2.7rem}
 .lg\:su-pb-32{padding-bottom:3.2rem}
 .lg\:su-pb-36{padding-bottom:3.6rem}
 .lg\:su-pb-\[11px\]{padding-bottom:11px}
+.lg\:su-pb-\[18\.9rem\]{padding-bottom:18.9rem}
 .lg\:su-pb-\[19\.3rem\]{padding-bottom:19.3rem}
 .lg\:su-pb-\[2px\]{padding-bottom:2px}
 .lg\:su-pb-\[8\.75px\]{padding-bottom:8.75px}
@@ -4581,12 +4701,14 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-pl-\[20\%\]{padding-left:20%}
 .lg\:su-pl-\[5\.2rem\]{padding-left:5.2rem}
 .lg\:su-pl-\[52px\]{padding-left:52px}
+.lg\:su-pr-0{padding-right:0}
 .lg\:su-pr-30{padding-right:3rem}
 .lg\:su-pr-72{padding-right:7.2rem}
 .lg\:su-pt-27{padding-top:2.7rem}
 .lg\:su-pt-36{padding-top:3.6rem}
 .lg\:su-pt-90{padding-top:9rem}
 .lg\:su-pt-\[17\.5rem\]{padding-top:17.5rem}
+.lg\:su-pt-\[27px\]{padding-top:27px}
 .lg\:su-text-left{text-align:left}
 .lg\:su-text-14{font-size:1.4rem}
 .lg\:su-text-15{font-size:1.5rem}
@@ -4673,17 +4795,29 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .xl\:su-order-2{order:2}
 .xl\:su-order-first{order:-9999}
 .xl\:su-mt-58{margin-top:5.8rem}
+.xl\:su-w-1\/4{width:25%}
 .xl\:su-min-w-\[35\.9rem\]{min-width:35.9rem}
+.xl\:su-max-w-600{max-width:60rem}
+.xl\:su-max-w-900{max-width:90rem}
 .xl\:su-translate-y-\[-220px\]{--tw-translate-y:-220px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .xl\:su-grid-cols-2{grid-template-columns:repeat(2, minmax(0, 1fr))}
+.xl\:su-flex-row-reverse{flex-direction:row-reverse}
+.xl\:su-gap-60{gap:6rem}
+.xl\:su-py-100{padding-top:10rem;padding-bottom:10rem}
 .xl\:su-pl-170{padding-left:17rem}
+.xl\:su-text-left{text-align:left}
+.xl\:su-text-\[2\.8rem\]{font-size:2.8rem}
 .xl\:su-text-\[3\.3rem\]{font-size:3.3rem}
 .xl\:su-text-\[6\.4rem\]{font-size:6.4rem}
 .xl\:su-text-\[6rem\]{font-size:6rem}}
 @media (min-width: 1500px){
+.\32xl\:su--mt-58{margin-top:-5.8rem}
 .\32xl\:su-mt-171{margin-top:17.1rem}
 .\32xl\:su-flex-row{flex-direction:row}
-.\32xl\:su-px-\[6\.6rem\]{padding-left:6.6rem;padding-right:6.6rem}}
+.\32xl\:su-px-\[6\.6rem\]{padding-left:6.6rem;padding-right:6.6rem}
+.\32xl\:su-py-140{padding-top:14rem;padding-bottom:14rem}
+.\32xl\:su-text-\[2\.9rem\]{font-size:2.9rem}
+.\32xl\:su-text-\[3\.3rem\]{font-size:3.3rem}}
 .\[\&\>\*\:last-child\]\:su-mb-0>*:last-child{margin-bottom:0}
 .\[\&\>\*\:last-child\]\:after\:su-content-\[\'\\u201D\'\]>*:last-child::after{--tw-content:'\u201D';content:var(--tw-content)}
 .\[\&\>\*\:last-child\]\:after\:su-content-\[\'\201D\'\]>*:last-child::after{--tw-content:'”';content:var(--tw-content)}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Make sure headline text remains black in dark mode

# Review By (Date)
- ASAP

# Criticality
10

# Review Tasks

## Setup tasks and/or behavior to test

1. Go here: https://news.stanford.edu/developreport/yvonne-test-standard-page/_nocache
2. Scroll to the bottom where there are 2 examples of the interactive photo card
3. If it isn't already, set the site to dark mode.
4. The headline should stay black when in dark mode
5. Review code

# Associated Issues and/or People
[UCP-3494](https://stanfordits.atlassian.net/browse/UCP-3494)


[UCP-3494]: https://stanfordits.atlassian.net/browse/UCP-3494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ