### PR TITLE
UCP-3444:  Media Feature component: dark mode :hocus, link

### DIFF
--- a/components/horizontal-video-testimonials/manifest.json
+++ b/components/horizontal-video-testimonials/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "horizontal-video-testimonials",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "namespace": "stanford-components",
   "description": "A section with a listing of horizontal video cards, with a section title and link to watch more.",
   "displayName": "Horizontal Video Testimonials",
@@ -39,13 +39,13 @@
               "ctaUrl": {
                 "title": "Matrix asset link",
                 "type": "string",
-                "description": "Select an asset to link to. If this field is filled out, it will be used instead of the manual link",
+                "description": "Select an Matrix asset/page to link to.",
                 "format": "matrix-asset-uri"
               },
               "ctaManualUrl": {
                 "title": "External/Manual link",
                 "type": "string",
-                "description": "Enter the full URL, including https://",
+                "description": "Enter the full URL, including https://. If this field is filled out, it will be used instead of the Matrix asset link.",
                 "default": "https://news.stanford.edu/video"
               },
               "bgImage": {

--- a/components/horizontal-video-testimonials/preview.data.json
+++ b/components/horizontal-video-testimonials/preview.data.json
@@ -2,6 +2,7 @@
     "sectionConfiguration": {
         "title": "Meet more students",
         "ctaText": "Watch all",
+        "ctaUrl": "matrix-asset://api-identifier/28192",
         "ctaManualUrl": "https://news.stanford.edu/video",
         "bgImage": "matrix-asset://api-identifier/99100",
         "marginBottom": "9"

--- a/components/horizontal-video-testimonials/server.jsx
+++ b/components/horizontal-video-testimonials/server.jsx
@@ -14,11 +14,11 @@ export default async (args, info) => {
   }
   const bgImageUrl = bgImageData?.url;
 
-  let ctaUrl = null;
-  if (args?.ctaUrl) {
-    ctaUrl = await basicAssetUri(ctx, args?.ctaUrl);
+  let ctaLink = null;
+  if (args.sectionConfiguration?.ctaUrl) {
+    ctaLink = await basicAssetUri(ctx, args.sectionConfiguration?.ctaUrl);
   }
-  const ctaInternalUrl = ctaUrl?.url;
+  const ctaInternalUrl = ctaLink?.url;
 
   /**
    * Testimonials data

--- a/components/media-feature/Component.jsx
+++ b/components/media-feature/Component.jsx
@@ -40,49 +40,49 @@ export default function MediaFeature({
   return (
     <Container width="full" paddingX={false}>
       <section className="su-py-45 su-px-20 su-flex su-justify-center su-relative md:su-py-72 md:su-px-50">
-        <div className="su-max-w-[1086px] su-flex su-flex-col su-items-center su-z-[2] su-relative su-p-38 before:su-content-[''] before:su-bg-foggy-light before:su-w-full before:su-h-full before:su-opacity-90 before:su-absolute before:su-z-[-1] before:su-top-0 before:su-left-0 md:su-flex-row md:su-gap-20 md:su-items-start lg:su-p-48 lg:su-gap-48">
-          {/* <div className="su-h-[224px] su-w-[224px] su-relative su-shrink-0 md:su-w-[182px] md:su-h-[182px] lg:su-w-[292px] lg:su-h-[292px]"> */}
-          <div
-            className={`${
-              mediaType === "Podcast" &&
-              "su-w-[224px] md:su-w-[182px] lg:su-w-[292px]"
-            } su-h-[224px] md:su-h-[182px] lg:su-h-[292px] su-relative su-shrink-0 ${
-              mediaType === "Book" && "media-feature__thumb"
-            }`}
-          >
-            <img
-              // src="https://picsum.photos/600/250"
-              src={imageData.url}
-              alt={imageData.attributes.alt}
-              className={thumbMap.get(mediaType)}
-              // className="su-media-card-thumb su-size-full su-object-scale-down su-object-center"
-              // className="su-absolute su-object-cover su-rounded-[8px] su-z-[2] su-flex-1 su-size-full su-shadow-[0px_4px_7px_0px_rgba(0,0,0,0.15)]"
-            />
-          </div>
-
-          <div>
-            <div className="su-py-20 su-w-full md:su-pb-27 md:su-pt-0 *:dark:su-text-black">
-              <FeaturedHeading type={mediaType} />
+        <a href={linkUrl} className="su-media-feature-title-link su-group">
+          <div className="su-max-w-[1086px] su-flex su-flex-col su-items-center su-z-[2] su-relative su-p-38 before:su-content-[''] before:su-bg-foggy-light before:su-w-full before:su-h-full before:su-opacity-90 before:su-absolute before:su-z-[-1] before:su-top-0 before:su-left-0 md:su-flex-row md:su-gap-20 md:su-items-start lg:su-p-48 lg:su-gap-48">
+            {/* <div className="su-h-[224px] su-w-[224px] su-relative su-shrink-0 md:su-w-[182px] md:su-h-[182px] lg:su-w-[292px] lg:su-h-[292px]"> */}
+            <div
+              className={`${
+                mediaType === "Podcast" &&
+                "su-w-[224px] md:su-w-[182px] lg:su-w-[292px]"
+              } su-h-[224px] md:su-h-[182px] lg:su-h-[292px] su-relative su-shrink-0 ${
+                mediaType === "Book" && "media-feature__thumb"
+              }`}
+            >
+              <img
+                // src="https://picsum.photos/600/250"
+                src={imageData.url}
+                alt={imageData.attributes.alt}
+                className={thumbMap.get(mediaType)}
+                // className="su-media-card-thumb su-size-full su-object-scale-down su-object-center"
+                // className="su-absolute su-object-cover su-rounded-[8px] su-z-[2] su-flex-1 su-size-full su-shadow-[0px_4px_7px_0px_rgba(0,0,0,0.15)]"
+              />
             </div>
 
-            <a href={linkUrl} className="su-media-feature-title-link su-group">
+            <div>
+              <div className="su-py-20 su-w-full md:su-pb-27 md:su-pt-0 *:dark:su-text-black">
+                <FeaturedHeading type={mediaType} />
+              </div>
+
               <h3 className="su-text-[35px] su-font-bold su-leading-tight su-m-0 su-pb-8 md:su-pb-19 md:su-text-[40px] lg:su-text-[43px]">
                 {title}
                 <span className="su-hidden lg:su-inline-block su-relative su-top-12 [&>*]:su-stroke-digital-red dark:[&>*]:su-stroke-dark-mode-red su-transition group-hocus:su--translate-y-01em group-hocus:su-translate-x-01em [&>svg]:su-translate-y-1">
                   <ExternalArrow size="large" />
                 </span>
               </h3>
-            </a>
 
-            <div className="su-w-full su-flex su-gap-[0.6rem] su-text-18 su-text-black-70 su-font-semibold su-items-center su-pb-15 su-leading-snug md:su-pb-19 md:su-text-16">
-              <MediaType type={mediaType} />
+              <div className="su-w-full su-flex su-gap-[0.6rem] su-text-18 su-text-black-70 su-font-semibold su-items-center su-pb-15 su-leading-snug md:su-pb-19 md:su-text-16">
+                <MediaType type={mediaType} />
+              </div>
+
+              <p className="su-text-18 su-w-full su-m-0 su-leading-[125%] su-text-black su-font-normal md:su-text-19 lg:su-text-21">
+                {teaserText}
+              </p>
             </div>
-
-            <p className="su-text-18 su-w-full su-m-0 su-leading-[125%] su-text-black su-font-normal md:su-text-19 lg:su-text-21">
-              {teaserText}
-            </p>
           </div>
-        </div>
+        </a>
 
         <img
           // src="https://picsum.photos/1300/"

--- a/components/media-feature/Component.jsx
+++ b/components/media-feature/Component.jsx
@@ -2,9 +2,10 @@ import React from "react";
 
 // import specific templates for the component
 import { Container } from "../../packages/grids/Container";
-import { SidebarHeading } from "../../packages/headings/Heading";
 import {
   Podcast,
+  FeaturedAudio,
+  FeaturedReading,
   ExternalArrow,
   BookOpenCover,
 } from "../../packages/SVG-library/SVG";
@@ -111,8 +112,8 @@ function MediaType({ type }) {
 function FeaturedHeading({ type }) {
   switch (type) {
     case "Podcast":
-      return <SidebarHeading icon="Featured audio" title="Featured audio" />;
+      return <FeaturedAudio variant="light" />;
     default:
-      return <SidebarHeading icon="Featured reading" title="Featured book" />;
+      return <FeaturedReading variant="light" />;
   }
 }

--- a/components/media-feature/main.css
+++ b/components/media-feature/main.css
@@ -3,5 +3,5 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 }
 
 .su-media-feature-title-link {
-  @apply su-no-underline hocus:su-underline dark:su-text-black hocus:su-text-digital-red dark:hocus:su-text-dark-mode-red;
+  @apply su-no-underline hocus:su-underline dark:su-text-black hocus:su-text-digital-red dark:hocus:su-text-digital-red;
 }

--- a/components/media-feature/manifest.json
+++ b/components/media-feature/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "media-feature",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "namespace": "stanford-components",
   "description": "THe media feature component is used to feature a singluar podcast or book.",
   "displayName": "Media Feature",

--- a/components/sidebar-navigation/Component.jsx
+++ b/components/sidebar-navigation/Component.jsx
@@ -22,12 +22,7 @@ import NavContent from "./Components/NavContent";
  * @constructor
  */
 
-export default function SidebarNavigation({
-  asset_url,
-  asset_short_name,
-  active,
-  menu,
-}) {
+export default function SidebarNavigation({ id, navData }) {
   const [navOpen, setNavOpen] = useState(false);
 
   useEffect(() => {
@@ -104,19 +99,20 @@ export default function SidebarNavigation({
         />
         {navOpen && (
           <NavContent
-            asset_url={asset_url}
-            asset_short_name={asset_short_name}
-            active={active}
-            menu={menu}
+            asset_url={navData.asset_url}
+            asset_short_name={navData.asset_short_name}
+            menu={navData.menu}
+            asset_assetid={navData.asset_assetid}
           />
         )}
       </div>
       <div className="su-hidden lg:su-block">
         <NavContent
-          asset_url={asset_url}
-          asset_short_name={asset_short_name}
-          active={active}
-          menu={menu}
+          id={id}
+          asset_url={navData.asset_url}
+          asset_short_name={navData.asset_short_name}
+          menu={navData.menu}
+          asset_assetid={navData.asset_assetid}
         />
       </div>
     </>

--- a/components/sidebar-navigation/Components/LinkItem.jsx
+++ b/components/sidebar-navigation/Components/LinkItem.jsx
@@ -23,7 +23,7 @@ export default function LinkItem({ level, url, shortName, active }) {
         level === "two" && "su-pl-25 su-pt-0 su-pb-10"
       )}
       href={url}
-      aria-current={active ? "page" : "false"}
+      aria-current={active}
     >
       {shortName}
     </a>

--- a/components/sidebar-navigation/Components/NavContent.jsx
+++ b/components/sidebar-navigation/Components/NavContent.jsx
@@ -13,9 +13,10 @@ import LinkItem from "./LinkItem";
  */
 
 export default function NavContent({
+  id,
   asset_url,
   asset_short_name,
-  active,
+  asset_assetid,
   menu,
 }) {
   return (
@@ -26,7 +27,7 @@ export default function NavContent({
             level="one"
             url={asset_url}
             shortName={asset_short_name}
-            active={active}
+            active={id === parseInt(asset_assetid) ? "page" : ""}
           />
         </li>
         {menu && menu.length ? (
@@ -39,7 +40,7 @@ export default function NavContent({
                       level="one"
                       url={item.asset_url}
                       shortName={item.asset_short_name}
-                      active={item.active}
+                      active={id === parseInt(item.asset_assetid) ? "page" : ""}
                     />
                     {item.asset_children && item.asset_children !== null && (
                       <ul className="su-list-none su-p-0">
@@ -54,7 +55,11 @@ export default function NavContent({
                                   level="two"
                                   url={subitem.asset_url}
                                   shortName={subitem.asset_short_name}
-                                  active={subitem.active}
+                                  active={
+                                    id === parseInt(subitem.asset_assetid)
+                                      ? "page"
+                                      : ""
+                                  }
                                 />
                               </li>
                             )

--- a/components/sidebar-navigation/client.jsx
+++ b/components/sidebar-navigation/client.jsx
@@ -1,13 +1,37 @@
 import { hydrateComponent } from "@squiz/xaccel-component-client-helpers";
 import Component from "./Component";
+import FetchAdapter from "../../packages/utils/fetchAdapter";
 
-(function () {
+(async function () {
   const componentName = "sidebar-navigation";
-  const base = document.querySelector(
-    `[data-hydration-component="${componentName}"]`
-  );
+  const base = document.querySelector(`[data-component="${componentName}"]`);
 
   if (!base) return;
 
-  hydrateComponent({ Component, componentName });
+  // Get our current props
+  const props = JSON.parse(base.getAttribute("data-hydration-props"));
+
+  // Construct call to menu API
+  let navURL = "";
+  const parent = props.root;
+  if (props.root) {
+    navURL = `https://news.stanford.edu/_api/dev/mx/menu?loc=${parent}`;
+  }
+
+  const adapter = new FetchAdapter();
+
+  if (parent !== "") {
+    adapter.url = navURL;
+  }
+
+  const navData = await adapter.fetch();
+
+  props.navData = navData;
+
+  base.setAttribute("data-hydration-props", JSON.stringify(props));
+
+  console.log(props);
+
+  // Hydrate the component
+  hydrateComponent({ Component, componentName: "sidebar-navigation" });
 })();

--- a/components/sidebar-navigation/manifest.json
+++ b/components/sidebar-navigation/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "sidebar-navigation",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "namespace": "stanford-components",
   "description": "A navigation element used for a collection of basic informational pages.",
   "displayName": "Sidebar Navigation",
@@ -19,14 +19,7 @@
       "entry": "./dist/server.cjs",
       "input": {
         "type": "object",
-        "properties": {
-          "title": {
-            "title": "Heading",
-            "description": "The heading text",
-            "type": "string",
-            "default": "Lorem ipsum dolor"
-          }
-        },
+        "properties": {},
         "required": []
       },
       "output": {

--- a/components/sidebar-navigation/server.jsx
+++ b/components/sidebar-navigation/server.jsx
@@ -2,9 +2,9 @@ import renderComponent from "../../packages/utils/render-component";
 import Component from "./Component";
 
 export default async (args) => {
-  return renderComponent({
-    Component,
-    componentName: "sidebar-navigation",
-    args,
-  });
+  // return renderComponent({
+  //   Component,
+  //   componentName: "sidebar-navigation",
+  //   args,
+  // });
 };

--- a/components/vertical-videos-panel/Component.jsx
+++ b/components/vertical-videos-panel/Component.jsx
@@ -1,0 +1,111 @@
+import React, { useState, useEffect } from "react";
+import hash from "object-hash";
+import { Carousel } from "../../packages/carousels/Carousel";
+import { Container } from "../../packages/grids/Container";
+import { LinkedHeading } from "../../packages/headings/Heading";
+import { VerticalVideoCard } from "../../packages/card/VerticalVideoCard/VerticalVideoCard";
+import * as styles from "./styles";
+
+/**
+ * Vertical Videos Panel component
+ *
+ * @param {object} sectionConfiguration
+ * Field data for the section
+ *
+ * @param {string} ctaInternalUrl
+ * The internal URL for the CTA from the Matrix asset selection
+ *
+ * @param {string} bgImageUrl
+ * The background image URL from the Matrix asset selection
+ *
+ * @param {array} videosArray
+ * An array of objects that will be used to render the vertical video cards
+ *
+ * @returns {JSX.Element}
+ * @constructor
+ */
+
+export default function VerticalVideosPanel({
+  sectionConfiguration,
+  ctaInternalUrl,
+  bgImageUrl,
+  videosArray,
+}) {
+  const { title, ctaText, ctaManualUrl, marginTop, marginBottom } =
+    sectionConfiguration;
+
+  const [cards, setCards] = useState([]);
+  const cardData = [];
+  const uniqueClass = hash.MD5(JSON.stringify(videosArray));
+
+  if (videosArray?.length) {
+    videosArray.forEach(
+      ({ youtubeId, heading, subheading, videoImageData }) => {
+        cardData.push(
+          <VerticalVideoCard
+            key={`${youtubeId}-${heading}`}
+            heading={heading}
+            subheading={subheading}
+            youtubeId={youtubeId}
+            videoImageUrl={videoImageData?.url}
+            videoImageAlt={videoImageData?.alt || heading}
+          />
+        );
+      }
+    );
+  }
+
+  // Can't get rid of the useEffect otherwise it would mess up the carousel slides
+  useEffect(() => {
+    setCards(cardData);
+  }, []);
+
+  return (
+    <Container
+      width="full"
+      paddingY={bgImageUrl ? "10" : ""}
+      paddingX={false}
+      marginTop={marginTop}
+      marginBottom={marginBottom}
+      className={styles.root}
+    >
+      <div className={styles.wrapper}>
+        <div className={styles.headingWrapper}>
+          <LinkedHeading
+            title={title}
+            ctaText={ctaText}
+            ctaLink={ctaManualUrl || ctaInternalUrl}
+            isAlwaysLight={!!bgImageUrl}
+            className={styles.sectionHeading}
+          />
+        </div>
+        {!!videosArray?.length && (
+          <>
+            {/* Only render carousel if there are more than 1 videos */}
+            {videosArray.length > 1 && (
+              <div className={styles.carouselWrapper}>
+                <Carousel
+                  variant="vertical-videos"
+                  slides={cards}
+                  isDark={!!bgImageUrl}
+                  uniqueClass={uniqueClass}
+                />
+              </div>
+            )}
+            <div className={styles.cardGridWrapper(videosArray.length === 1)}>
+              <div className={styles.cardGrid(videosArray.length === 1)}>
+                {cardData}
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+      {bgImageUrl && (
+        <>
+          <img src={bgImageUrl} alt="" className={styles.bgImage} />
+          <div aria-hidden="true" className={styles.overlay} />
+        </>
+      )}
+    </Container>
+  );
+}

--- a/components/vertical-videos-panel/client.jsx
+++ b/components/vertical-videos-panel/client.jsx
@@ -1,0 +1,13 @@
+import { hydrateComponent } from "@squiz/xaccel-component-client-helpers";
+import Component from "./Component";
+
+(function () {
+  const componentName = "vertical-videos-panel";
+  const target = document.querySelector(
+    `[data-hydration-component="${componentName}"]`
+  );
+
+  if (!target) return;
+
+  hydrateComponent({ Component, componentName });
+})();

--- a/components/vertical-videos-panel/manifest.json
+++ b/components/vertical-videos-panel/manifest.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "http://localhost:3000/schemas/v1.json#",
+  "name": "vertical-videos-panel",
+  "version": "0.0.4",
+  "namespace": "stanford-components",
+  "description": "A section that displays up to 3 vertical YouTube videos, with a section title and link to watch more. On smaller devices, the videos will be displayed in a carousel if there are more than 1.",
+  "displayName": "Vertical Videos Panel",
+  "mainFunction": "main",
+  "icon": {
+    "id": "video_library",
+    "color": {
+      "type": "enum",
+      "value": "blue"
+    }
+  },
+  "functions": [
+    {
+      "name": "main",
+      "entry": "./dist/server.cjs",
+      "input": {
+        "type": "object",
+        "properties": {
+          "sectionConfiguration": {
+            "title": "Section Configuration",
+            "description": "The heading for the section, appearing above the video cards. If the title is empty, the heading and call to action link will be hidden.",
+            "type": "object",
+            "required": [],
+            "properties": {
+              "title": {
+                "title": "Section heading",
+                "type": "string",
+                "default": "Meet more students"
+              },
+              "ctaText": {
+                "title": "Heading CTA link text",
+                "type": "string",
+                "default": "Watch all"
+              },
+              "ctaUrl": {
+                "title": "Matrix asset link",
+                "type": "string",
+                "description": "Select an Matrix asset/page to link to.",
+                "format": "matrix-asset-uri"
+              },
+              "ctaManualUrl": {
+                "title": "External/Manual link",
+                "type": "string",
+                "description": "Enter the full URL, including https://. If this field is filled out, it will be used instead of the Matrix asset link.",
+                "default": "https://news.stanford.edu/video"
+              },
+              "bgImage": {
+                "title": "Background image",
+                "description": "Select a background image for the section. A dark overlay will be applied over the image.",
+                "type": "string",
+                "format": "matrix-asset-uri"
+              },
+              "marginTop": {
+                "title": "Spacing above (top margin)",
+                "description": "Add spacing above the section. 'Base' is the smallest with '10' (default) being the largest option. Selecting 'default' will use the default site-wide vertical spacing between components.",
+                "type": "string",
+                "default": "10",
+                "enum": [
+                  "default",
+                  "base",
+                  "1",
+                  "2",
+                  "3",
+                  "4",
+                  "5",
+                  "6",
+                  "7",
+                  "8",
+                  "9",
+                  "10"
+                ]
+              },
+              "marginBottom": {
+                "title": "Spacing below (bottom margin)",
+                "description": "Add spacing below the section. 'Base' is the smallest with '10' (default) being the largest option. Selecting 'default' will use the default site-wide vertical spacing between components.",
+                "type": "string",
+                "default": "10",
+                "enum": [
+                  "default",
+                  "base",
+                  "1",
+                  "2",
+                  "3",
+                  "4",
+                  "5",
+                  "6",
+                  "7",
+                  "8",
+                  "9",
+                  "10"
+                ]
+              }
+            }
+          },
+          "videos": {
+            "title": "Vertical video cards",
+            "description": "Enter the details for each vertical video card.",
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 3,
+            "items": {
+              "type": "object",
+              "properties": {
+                "heading": {
+                  "title": "Card heading",
+                  "type": "string"
+                },
+                "subheading": {
+                  "title": "Subheading",
+                  "description": "Smaller text below the card heading.",
+                  "type": "string"
+                },
+                "videoImage": {
+                  "title": "Video preview image",
+                  "description": "Select an image to use as the video preview. The aspect ratio of the image displayed will be the same as the YouTube shorts which is 9x16.",
+                  "type": "string",
+                  "format": "matrix-asset-uri"
+                },
+                "youtubeId": {
+                  "title": "YouTube video ID",
+                  "description": "Enter the video ID from YouTube.",
+                  "type": "string"
+                }
+              },
+              "required": []
+            }
+          }
+        },
+        "required": []
+      },
+      "output": {
+        "responseType": "html",
+        "staticFiles": [
+          {
+            "location": "header",
+            "file": {
+              "type": "css",
+              "filepath": "global.css"
+            }
+          },
+          {
+            "location": "footer",
+            "file": {
+              "type": "js",
+              "filepath": "client.js"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "staticFiles": {
+    "locationRoot": "./dist"
+  },
+  "mockedUris": {
+    "matrix-asset://api-identifier/99100": {
+      "type": "file",
+      "path": "mocked-uris/99100.json"
+    },
+    "matrix-asset://api-identifier/28192": {
+      "type": "file",
+      "path": "mocked-uris/28192.json"
+    },
+    "matrix-asset://api-identifier/128610": {
+      "type": "file",
+      "path": "mocked-uris/128610.json"
+    },
+    "matrix-asset://api-identifier/125800": {
+      "type": "file",
+      "path": "mocked-uris/125800.json"
+    }
+  },
+  "previews": {
+    "default": {
+      "functionData": {
+        "main": {
+          "inputData": {
+            "type": "file",
+            "path": "preview.data.json"
+          },
+          "wrapper": {
+            "path": "../../packages/__globalPreview/campaign.html"
+          }
+        }
+      }
+    }
+  }
+}

--- a/components/vertical-videos-panel/mocked-uris/125800.json
+++ b/components/vertical-videos-panel/mocked-uris/125800.json
@@ -1,0 +1,754 @@
+{
+  "id": "125800",
+  "type": "image",
+  "type_name": "Image",
+  "version": "0.1.0",
+  "name": "jenny-martinez.jpg",
+  "short_name": "Jenny Martinez",
+  "status": { "id": 16, "code": "live", "name": "Live" },
+  "created": { "date": "2023-12-10T21:08:41-08:00", "user_id": "32325" },
+  "updated": { "date": "2023-12-10T21:08:50-08:00", "user_id": "32325" },
+  "published": { "date": "2023-12-10T21:08:49-08:00", "user_id": "32325" },
+  "status_changed": { "date": "2023-12-10T21:08:49-08:00", "user_id": "32325" },
+  "urls": [
+    "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/jenny-martinez.jpg"
+  ],
+  "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/jenny-martinez.jpg",
+  "attributes": {
+    "variety_count": 19,
+    "size": 56417,
+    "height": 196,
+    "width": 293,
+    "name": "jenny-martinez.jpg",
+    "alt": "Jenny Martinez",
+    "title": "Jenny Martinez",
+    "allow_unrestricted": true,
+    "caption": ""
+  },
+  "metadata": null,
+  "contents": "\"Jenny",
+  "additional": {
+    "file_info": {
+      "file_name": "jenny-martinez.jpg",
+      "size_readable": "55.1 KB",
+      "size_bytes": 56417,
+      "width": 293,
+      "height": 196,
+      "modified_readable": "Dec 10, 2023 9:08 PM",
+      "modified_unix": 1702271322
+    },
+    "varieties": [
+      {
+        "id": "125800:v1",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "100w",
+        "short_name": "100w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/100w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/100w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "100w.jpg",
+          "name": "100w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 3242,
+          "variety_height": 100,
+          "variety_width": 100,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 100,
+          "height": 0,
+          "width": 0,
+          "constrain": "centre_weighted_square"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v2",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "150w",
+        "short_name": "150w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/150w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/150w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "150w.jpg",
+          "name": "150w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 5143,
+          "variety_height": 150,
+          "variety_width": 150,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 150,
+          "height": 0,
+          "width": 0,
+          "constrain": "centre_weighted_square"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v3",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "200w",
+        "short_name": "200w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/200w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/200w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "200w.jpg",
+          "name": "200w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 5953,
+          "variety_height": 134,
+          "variety_width": 200,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 200,
+          "width": 200,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v4",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "300w",
+        "short_name": "300w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/300w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/300w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "300w.jpg",
+          "name": "300w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 5953,
+          "variety_height": 134,
+          "variety_width": 200,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 300,
+          "width": 200,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v5",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "345w",
+        "short_name": "345w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/345w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/345w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "345w.jpg",
+          "name": "345w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 12296,
+          "variety_height": 231,
+          "variety_width": 345,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 555,
+          "width": 345,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v6",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "375w",
+        "short_name": "375w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/375w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/375w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "375w.jpg",
+          "name": "375w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 13656,
+          "variety_height": 251,
+          "variety_width": 375,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 200,
+          "width": 375,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v7",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "400w",
+        "short_name": "400w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/400w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/400w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "400w.jpg",
+          "name": "400w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 15040,
+          "variety_height": 268,
+          "variety_width": 400,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 100,
+          "width": 400,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v8",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "555w",
+        "short_name": "555w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/555w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/555w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "555w.jpg",
+          "name": "555w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 24024,
+          "variety_height": 371,
+          "variety_width": 555,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 555,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v9",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "600w",
+        "short_name": "600w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/600w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/600w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "600w.jpg",
+          "name": "600w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 27047,
+          "variety_height": 401,
+          "variety_width": 600,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 600,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v10",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "690w",
+        "short_name": "690w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/690w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/690w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "690w.jpg",
+          "name": "690w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 33712,
+          "variety_height": 462,
+          "variety_width": 690,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 690,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v11",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "705w",
+        "short_name": "705w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/705w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/705w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "705w.jpg",
+          "name": "705w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 34757,
+          "variety_height": 472,
+          "variety_width": 705,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 705,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v12",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "750w",
+        "short_name": "750w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/750w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/750w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "750w.jpg",
+          "name": "750w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 38284,
+          "variety_height": 502,
+          "variety_width": 750,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 750,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v13",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "795w",
+        "short_name": "795w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/795w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/795w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "795w.jpg",
+          "name": "795w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 42162,
+          "variety_height": 532,
+          "variety_width": 795,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 795,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v14",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "960w",
+        "short_name": "960w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/960w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/960w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "960w.jpg",
+          "name": "960w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 56671,
+          "variety_height": 642,
+          "variety_width": 960,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 960,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v15",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1024w",
+        "short_name": "1024w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/1024w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/1024w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1024w.jpg",
+          "name": "1024w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 62899,
+          "variety_height": 685,
+          "variety_width": 1024,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1024,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v16",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1110w",
+        "short_name": "1110w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/1110w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/1110w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1110w.jpg",
+          "name": "1110w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 71817,
+          "variety_height": 743,
+          "variety_width": 1110,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1110,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v17",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1410w",
+        "short_name": "1410w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/1410w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/1410w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1410w.jpg",
+          "name": "1410w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 105131,
+          "variety_height": 943,
+          "variety_width": 1410,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1410,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "125800:v18",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1500w",
+        "short_name": "1500w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/1500w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0016/125800/varieties/1500w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1500w.jpg",
+          "name": "1500w",
+          "title": "Jenny Martinez",
+          "caption": "",
+          "variety_size": 116374,
+          "variety_height": 1003,
+          "variety_width": 1500,
+          "alt": "Jenny Martinez",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1500,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      }
+    ],
+    "exif": {
+      "image": {
+        "ImageHeight": 196,
+        "ImageWidth": 293,
+        "ResolutionUnit": 0,
+        "XResolution": 72,
+        "YResolution": 72
+      }
+    }
+  }
+}

--- a/components/vertical-videos-panel/mocked-uris/128610.json
+++ b/components/vertical-videos-panel/mocked-uris/128610.json
@@ -1,0 +1,1008 @@
+{
+  "id": "128610",
+  "type": "image",
+  "type_name": "Image",
+  "version": "0.1.0",
+  "name": "auden-book.png",
+  "short_name": "Book Cover 1",
+  "status": {
+    "id": 16,
+    "code": "live",
+    "name": "Live"
+  },
+  "created": {
+    "date": "2024-01-29T18:47:51-08:00",
+    "user_id": "32325"
+  },
+  "updated": {
+    "date": "2024-01-29T18:48:06-08:00",
+    "user_id": "32325"
+  },
+  "published": {
+    "date": "2024-01-29T18:48:06-08:00",
+    "user_id": "32325"
+  },
+  "status_changed": {
+    "date": "2024-01-29T18:48:06-08:00",
+    "user_id": "32325"
+  },
+  "urls": [
+    "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/auden-book.png"
+  ],
+  "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/auden-book.png",
+  "attributes": {
+    "title": "Book Cover 1",
+    "allow_unrestricted": true,
+    "variety_count": 19,
+    "size": 97942,
+    "height": 495,
+    "width": 330,
+    "caption": "",
+    "alt": "This is a cover of a book",
+    "name": "auden-book.png"
+  },
+  "metadata": null,
+  "contents": "<img src=\"https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/auden-book.png\" width=\"330\" height=\"495\" alt=\"This is a cover of a book\" title=\"Book Cover 1\" />",
+  "additional": {
+    "file_info": {
+      "file_name": "auden-book.png",
+      "size_readable": "95.6 KB",
+      "size_bytes": 97942,
+      "width": 330,
+      "height": 495,
+      "modified_readable": "Jan 29, 2024 6:47 PM",
+      "modified_unix": 1706582871
+    },
+    "varieties": [
+      {
+        "id": "128610:v1",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "100w",
+        "short_name": "100w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/100w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/100w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "100w.png",
+          "name": "100w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 11557,
+          "variety_height": 100,
+          "variety_width": 100,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 100,
+          "height": 0,
+          "width": 0,
+          "constrain": "centre_weighted_square"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v2",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "150w",
+        "short_name": "150w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/150w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/150w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "150w.png",
+          "name": "150w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 21965,
+          "variety_height": 150,
+          "variety_width": 150,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 150,
+          "height": 0,
+          "width": 0,
+          "constrain": "centre_weighted_square"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v3",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "200w",
+        "short_name": "200w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/200w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/200w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "200w.png",
+          "name": "200w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 48225,
+          "variety_height": 300,
+          "variety_width": 200,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 200,
+          "width": 200,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v4",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "300w",
+        "short_name": "300w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/300w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/300w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "300w.png",
+          "name": "300w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 48225,
+          "variety_height": 300,
+          "variety_width": 200,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 300,
+          "width": 200,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v5",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "345w",
+        "short_name": "345w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/345w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/345w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "345w.png",
+          "name": "345w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 118459,
+          "variety_height": 518,
+          "variety_width": 345,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 555,
+          "width": 345,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v6",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "375w",
+        "short_name": "375w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/375w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/375w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "375w.png",
+          "name": "375w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 135213,
+          "variety_height": 563,
+          "variety_width": 375,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 200,
+          "width": 375,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v7",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "400w",
+        "short_name": "400w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/400w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/400w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "400w.png",
+          "name": "400w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 154682,
+          "variety_height": 600,
+          "variety_width": 400,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 100,
+          "width": 400,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v8",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "555w",
+        "short_name": "555w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/555w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/555w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "555w.png",
+          "name": "555w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 247367,
+          "variety_height": 833,
+          "variety_width": 555,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 555,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v9",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "600w",
+        "short_name": "600w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/600w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/600w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "600w.png",
+          "name": "600w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 258526,
+          "variety_height": 900,
+          "variety_width": 600,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 600,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v10",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "690w",
+        "short_name": "690w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/690w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/690w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "690w.png",
+          "name": "690w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 298587,
+          "variety_height": 1035,
+          "variety_width": 690,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 690,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v11",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "705w",
+        "short_name": "705w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/705w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/705w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "705w.png",
+          "name": "705w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 319317,
+          "variety_height": 1058,
+          "variety_width": 705,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 705,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v12",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "750w",
+        "short_name": "750w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/750w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/750w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "750w.png",
+          "name": "750w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 312296,
+          "variety_height": 1125,
+          "variety_width": 750,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 750,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v13",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "795w",
+        "short_name": "795w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/795w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/795w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "795w.png",
+          "name": "795w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 364179,
+          "variety_height": 1193,
+          "variety_width": 795,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 795,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v14",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "960w",
+        "short_name": "960w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/960w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/960w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "960w.png",
+          "name": "960w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 265831,
+          "variety_height": 1440,
+          "variety_width": 960,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 960,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v15",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1024w",
+        "short_name": "1024w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/1024w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/1024w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1024w.png",
+          "name": "1024w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 283805,
+          "variety_height": 1536,
+          "variety_width": 1024,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1024,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v16",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1110w",
+        "short_name": "1110w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/1110w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/1110w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1110w.png",
+          "name": "1110w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 436011,
+          "variety_height": 1665,
+          "variety_width": 1110,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1110,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v17",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1410w",
+        "short_name": "1410w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/1410w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/1410w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1410w.png",
+          "name": "1410w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 483997,
+          "variety_height": 2115,
+          "variety_width": 1410,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1410,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "128610:v18",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1500w",
+        "short_name": "1500w",
+        "status": {
+          "id": 16,
+          "code": "live",
+          "name": "Live"
+        },
+        "created": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "updated": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "published": {
+          "date": null,
+          "user_id": null
+        },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/1500w.png"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0018/128610/varieties/1500w.png",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1500w.png",
+          "name": "1500w",
+          "title": "Book Cover 1",
+          "caption": "",
+          "variety_size": 581363,
+          "variety_height": 2250,
+          "variety_width": 1500,
+          "alt": "This is a cover of a book",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1500,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      }
+    ],
+    "exif": {
+      "image": {
+        "ImageHeight": 495,
+        "ImageWidth": 330
+      },
+      "thumbnail": {
+        "Compression": 0
+      },
+      "exif": {
+        "ExifImageHeight": 495,
+        "ExifImageWidth": 330
+      }
+    }
+  }
+}

--- a/components/vertical-videos-panel/mocked-uris/28192.json
+++ b/components/vertical-videos-panel/mocked-uris/28192.json
@@ -1,0 +1,31 @@
+{
+  "id": "28192",
+  "type": "data_record",
+  "type_name": "Data Record",
+  "version": "0.0.1",
+  "name": "News",
+  "short_name": "News",
+  "status": {
+    "id": 2,
+    "code": "under_construction",
+    "name": "Under Construction"
+  },
+  "created": { "date": "2023-08-25T06:08:06-07:00", "user_id": "57" },
+  "updated": { "date": "2023-08-25T06:08:07-07:00", "user_id": "57" },
+  "published": { "date": null, "user_id": null },
+  "status_changed": { "date": "2023-08-25T06:08:06-07:00", "user_id": "57" },
+  "urls": [
+    "https://sug-web.matrix.squiz.cloud/_media/taxonomy/content-warehouse/front-end-taxonomy/content-type/news"
+  ],
+  "url": "https://sug-web.matrix.squiz.cloud/_media/taxonomy/content-warehouse/front-end-taxonomy/content-type/news",
+  "attributes": { "name": "News" },
+  "metadata": {
+    "slug": [],
+    "description": [],
+    "itemId": [],
+    "parentSection": [],
+    "featured": []
+  },
+  "contents": "",
+  "additional": {}
+}

--- a/components/vertical-videos-panel/mocked-uris/99100.json
+++ b/components/vertical-videos-panel/mocked-uris/99100.json
@@ -1,0 +1,754 @@
+{
+  "id": "99100",
+  "type": "image",
+  "type_name": "Image",
+  "version": "0.1.1",
+  "name": "RDE-Sustainability-Waste-Specialist-Haley-Todd-with-a-Recycle-for-Change-Bin-scaled-1.jpg",
+  "short_name": "RDE-Sustainability-Waste-Specialist-Haley-Todd-with-a-Recycle-for-Change-Bin-scaled-1.jpg",
+  "status": { "id": 16, "code": "live", "name": "Live" },
+  "created": { "date": "2023-12-04T20:04:03-08:00", "user_id": "32242" },
+  "updated": { "date": "2023-12-04T20:05:06-08:00", "user_id": "32242" },
+  "published": { "date": "2023-12-04T20:04:13-08:00", "user_id": "32242" },
+  "status_changed": { "date": "2023-12-04T20:04:13-08:00", "user_id": "32242" },
+  "urls": [
+    "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/RDE-Sustainability-Waste-Specialist-Haley-Todd-with-a-Recycle-for-Change-Bin-scaled-1.jpg"
+  ],
+  "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/RDE-Sustainability-Waste-Specialist-Haley-Todd-with-a-Recycle-for-Change-Bin-scaled-1.jpg",
+  "attributes": {
+    "variety_count": 19,
+    "size": 411964,
+    "height": 998,
+    "width": 1500,
+    "title": "RDE-Sustainability-Waste-Specialist-Haley-Todd-with-a-Recycle-for-Change-Bin-scaled-1.jpg",
+    "name": "RDE-Sustainability-Waste-Specialist-Haley-Todd-with-a-Recycle-for-Change-Bin-scaled-1.jpg",
+    "allow_unrestricted": true,
+    "caption": "",
+    "alt": ""
+  },
+  "metadata": null,
+  "contents": "\"\"",
+  "additional": {
+    "file_info": {
+      "file_name": "RDE-Sustainability-Waste-Specialist-Haley-Todd-with-a-Recycle-for-Change-Bin-scaled-1.jpg",
+      "size_readable": "402.3 KB",
+      "size_bytes": 411964,
+      "width": 1500,
+      "height": 998,
+      "modified_readable": "Dec 4, 2023 8:04 PM",
+      "modified_unix": 1701749096
+    },
+    "varieties": [
+      {
+        "id": "99100:v1",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "100w",
+        "short_name": "100w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/100w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/100w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "100w.jpg",
+          "name": "100w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 4761,
+          "variety_height": 100,
+          "variety_width": 100,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 100,
+          "height": 0,
+          "width": 0,
+          "constrain": "centre_weighted_square"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v2",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "150w",
+        "short_name": "150w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/150w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/150w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "150w.jpg",
+          "name": "150w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 8822,
+          "variety_height": 150,
+          "variety_width": 150,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 150,
+          "height": 0,
+          "width": 0,
+          "constrain": "centre_weighted_square"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v3",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "200w",
+        "short_name": "200w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/200w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/200w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "200w.jpg",
+          "name": "200w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 10100,
+          "variety_height": 133,
+          "variety_width": 200,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 200,
+          "width": 200,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v4",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "300w",
+        "short_name": "300w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/300w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/300w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "300w.jpg",
+          "name": "300w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 10100,
+          "variety_height": 133,
+          "variety_width": 200,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 300,
+          "width": 200,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v5",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "345w",
+        "short_name": "345w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/345w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/345w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "345w.jpg",
+          "name": "345w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 25646,
+          "variety_height": 230,
+          "variety_width": 345,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 555,
+          "width": 345,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v6",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "375w",
+        "short_name": "375w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/375w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/375w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "375w.jpg",
+          "name": "375w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 29473,
+          "variety_height": 250,
+          "variety_width": 375,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 200,
+          "width": 375,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v7",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "400w",
+        "short_name": "400w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/400w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/400w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "400w.jpg",
+          "name": "400w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 32615,
+          "variety_height": 266,
+          "variety_width": 400,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 100,
+          "width": 400,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v8",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "555w",
+        "short_name": "555w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/555w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/555w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "555w.jpg",
+          "name": "555w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 57315,
+          "variety_height": 369,
+          "variety_width": 555,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 555,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v9",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "600w",
+        "short_name": "600w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/600w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/600w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "600w.jpg",
+          "name": "600w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 64815,
+          "variety_height": 399,
+          "variety_width": 600,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 600,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v10",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "690w",
+        "short_name": "690w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/690w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/690w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "690w.jpg",
+          "name": "690w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 82304,
+          "variety_height": 459,
+          "variety_width": 690,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 690,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v11",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "705w",
+        "short_name": "705w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/705w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/705w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "705w.jpg",
+          "name": "705w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 85275,
+          "variety_height": 469,
+          "variety_width": 705,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 705,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v12",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "750w",
+        "short_name": "750w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/750w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/750w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "750w.jpg",
+          "name": "750w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 98514,
+          "variety_height": 499,
+          "variety_width": 750,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 750,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v13",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "795w",
+        "short_name": "795w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/795w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/795w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "795w.jpg",
+          "name": "795w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 104385,
+          "variety_height": 529,
+          "variety_width": 795,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 795,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v14",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "960w",
+        "short_name": "960w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/960w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/960w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "960w.jpg",
+          "name": "960w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 141163,
+          "variety_height": 639,
+          "variety_width": 960,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 960,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v15",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1024w",
+        "short_name": "1024w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/1024w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/1024w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1024w.jpg",
+          "name": "1024w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 157660,
+          "variety_height": 681,
+          "variety_width": 1024,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1024,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v16",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1110w",
+        "short_name": "1110w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/1110w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/1110w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1110w.jpg",
+          "name": "1110w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 180443,
+          "variety_height": 739,
+          "variety_width": 1110,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1110,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v17",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1410w",
+        "short_name": "1410w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/1410w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/1410w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1410w.jpg",
+          "name": "1410w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 271404,
+          "variety_height": 938,
+          "variety_width": 1410,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1410,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      },
+      {
+        "id": "99100:v18",
+        "type": "image_variety",
+        "type_name": "Image Variety",
+        "version": "",
+        "name": "1500w",
+        "short_name": "1500w",
+        "status": { "id": 16, "code": "live", "name": "Live" },
+        "created": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "updated": { "date": "1969-12-31T16:00:00-08:00", "user_id": null },
+        "published": { "date": null, "user_id": null },
+        "status_changed": {
+          "date": "1969-12-31T16:00:00-08:00",
+          "user_id": null
+        },
+        "urls": [
+          "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/1500w.jpg"
+        ],
+        "url": "https://sug-web.matrix.squiz.cloud/__data/assets/image/0019/99100/varieties/1500w.jpg",
+        "attributes": {
+          "variety_type": "resize",
+          "filename": "1500w.jpg",
+          "name": "1500w",
+          "title": "ezgif-5-cfc21cd59c.jpg",
+          "caption": "",
+          "variety_size": 389195,
+          "variety_height": 998,
+          "variety_width": 1500,
+          "alt": "",
+          "dimension_min": 0,
+          "dimension": 0,
+          "height": 0,
+          "width": 1500,
+          "constrain": "width"
+        },
+        "metadata": null,
+        "contents": "",
+        "additional": {}
+      }
+    ],
+    "exif": {
+      "image": {
+        "ImageHeight": 998,
+        "ImageWidth": 1500,
+        "ResolutionUnit": 0,
+        "XResolution": 1,
+        "YResolution": 1
+      }
+    }
+  }
+}

--- a/components/vertical-videos-panel/preview.data.json
+++ b/components/vertical-videos-panel/preview.data.json
@@ -1,0 +1,30 @@
+{
+    "sectionConfiguration": {
+        "title": "Meet more students",
+        "ctaText": "Watch all",
+        "ctaUrl": "matrix-asset://api-identifier/28192",
+        "ctaManualUrl": "https://news.stanford.edu/video",
+        "bgImage": "matrix-asset://api-identifier/99100",
+        "marginBottom": "9"
+    },
+    "videos": [
+        {
+            "heading": "Adam",
+            "subheading": "Class of 2024",
+            "youtubeId": "52H4lQIEQdk",
+            "videoImage": "matrix-asset://api-identifier/99100"
+        },
+        {
+            "heading": "Nadia",
+            "subheading": "Class of 2024",
+            "youtubeId": "2cgyrPLFg74",
+            "videoImage": "matrix-asset://api-identifier/128610"
+        },
+        {
+            "heading": "Stanford University",
+            "subheading": "Class of 2026",
+            "youtubeId": "2cgyrPLFg74",
+            "videoImage": "matrix-asset://api-identifier/125800"
+        }
+    ]
+}

--- a/components/vertical-videos-panel/server.jsx
+++ b/components/vertical-videos-panel/server.jsx
@@ -1,0 +1,57 @@
+import renderComponent from "../../packages/utils/render-component";
+import Component from "./Component";
+import basicAssetUri from "../../packages/utils/basicAssetUri";
+
+export default async (args, info) => {
+  const { ctx } = info;
+
+  /**
+   * Section configuration data
+   */
+  let bgImageData = null;
+  if (args?.sectionConfiguration?.bgImage) {
+    bgImageData = await basicAssetUri(ctx, args.sectionConfiguration.bgImage);
+  }
+  const bgImageUrl = bgImageData?.url;
+
+  let ctaLink = null;
+  if (args.sectionConfiguration?.ctaUrl) {
+    ctaLink = await basicAssetUri(ctx, args.sectionConfiguration?.ctaUrl);
+  }
+  const ctaInternalUrl = ctaLink?.url;
+
+  /**
+   * Vertical video cards data
+   */
+  const { videos } = args;
+  const videosArray = await Promise.all(
+    videos.map(async (video) => {
+      const { heading, subheading, videoImage, youtubeId } = video;
+
+      let videoImageData = null;
+      if (videoImage) {
+        videoImageData = await basicAssetUri(ctx, videoImage);
+      }
+
+      return {
+        heading,
+        subheading,
+        videoImageData,
+        youtubeId,
+      };
+    })
+  );
+
+  const renderProps = {
+    ...args,
+    bgImageUrl,
+    ctaInternalUrl,
+    videosArray,
+  };
+
+  return renderComponent({
+    Component,
+    componentName: "vertical-videos-panel",
+    args: renderProps,
+  });
+};

--- a/components/vertical-videos-panel/styles.js
+++ b/components/vertical-videos-panel/styles.js
@@ -1,0 +1,21 @@
+import { cnb } from "cnbuilder";
+
+export const root = "su-relative su-break-words";
+export const wrapper = "su-relative su-z-30";
+export const headingWrapper = "su-cc";
+export const sectionHeading = "2xl:su-px-[17rem] su-rs-mb-5";
+
+export const cardGridWrapper = (isSingleVideo) =>
+  cnb("su-cc", isSingleVideo ? "su-block" : "su-hidden lg:su-block");
+export const cardGrid = (isSingleVideo) =>
+  cnb(
+    "su-relative su-mx-auto su-flex  su-justify-center su-gap-20 xl:su-gap-40 su-z-30",
+    isSingleVideo
+      ? "*:su-basis-4/5 *:su-max-w-[45rem] *:lg:su-basis-1/3"
+      : "*:lg:su-basis-1/3"
+  );
+export const carouselWrapper = "lg:su-hidden";
+export const bgImage =
+  "su-absolute su-size-full su-inset-0 su-object-cover su-inset-0";
+export const overlay =
+  "su-absolute su-size-full su-inset-0 su-z-10 su-bg-black-true/75";

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -1960,8 +1960,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-media-feature-title-link:hover{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity));text-decoration-line:underline}
 .su-media-feature-title-link:focus{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity));text-decoration-line:underline}
 :is(.su-dark .su-media-feature-title-link){--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-:is(.su-dark .su-media-feature-title-link:hover){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-:is(.su-dark .su-media-feature-title-link:focus){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .su-media-feature-title-link:hover){--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
+:is(.su-dark .su-media-feature-title-link:focus){--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 @media (min-width: 992px){
 [data-component="media-carousel"] .su-component-container .component-slider{margin-left:auto;margin-right:auto}}
 [data-component="media-carousel"] .swiper-slide-visible .su-media-card-thumb{transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
@@ -2098,7 +2098,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 }
 .su-bg-gradient-light-red-h-reverse{background-image:linear-gradient(to left, var(--tw-gradient-stops));--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
 :is(.su-dark .su-bg-gradient-light-red-h-reverse){background-image:linear-gradient(to top left, var(--tw-gradient-stops));--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:rgb(39 153 137 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #279989 var(--tw-gradient-via-position), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
-.su-aspect-h-16{--tw-aspect-h:16}
 .su-aspect-h-2{--tw-aspect-h:2}
 .su-aspect-w-1{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:1}
 .su-aspect-w-1 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
@@ -2106,8 +2105,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-aspect-w-2 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
 .su-aspect-w-3{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:3}
 .su-aspect-w-3 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
-.su-aspect-w-9{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:9}
-.su-aspect-w-9 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
 .su-button{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;cursor:pointer;display:inline-block;border:none;font-weight:400;line-height:1;text-align:center;text-decoration:none;width:auto;transition:background-color 0.25s ease-in-out, color 0.25s ease-in-out;padding:1rem 2rem;background-color:#B1040E;color:#fff;}
 .su-button:active, .su-button:hover, .su-button:focus{text-decoration:underline}
 .su-button:hover, .su-button:focus{background-color:#2E2D29;color:#fff}
@@ -2176,11 +2173,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mt-2{margin-top:3.6rem}}
 @media (min-width: 1500px){
 .su-rs-mt-2{margin-top:3.8rem}}
-.su-rs-pt-2{padding-top:3rem;}
-@media (min-width: 768px){
-.su-rs-pt-2{padding-top:3.6rem}}
-@media (min-width: 1500px){
-.su-rs-pt-2{padding-top:3.8rem}}
 .su-rs-mb-2{margin-bottom:3rem;}
 @media (min-width: 768px){
 .su-rs-mb-2{margin-bottom:3.6rem}}
@@ -2281,11 +2273,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mb-6{margin-bottom:9rem}}
 @media (min-width: 1500px){
 .su-rs-mb-6{margin-bottom:9.5rem}}
-.su-rs-pb-6{padding-bottom:4.5rem;}
-@media (min-width: 768px){
-.su-rs-pb-6{padding-bottom:9rem}}
-@media (min-width: 1500px){
-.su-rs-pb-6{padding-bottom:9.5rem}}
 .su-rs-py-6{padding-top:4.5rem;padding-bottom:4.5rem;}
 @media (min-width: 768px){
 .su-rs-py-6{padding-top:9rem;padding-bottom:9rem}}
@@ -2376,11 +2363,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mt-neg1{margin-top:1.2rem}}
 @media (min-width: 1500px){
 .su-rs-mt-neg1{margin-top:1.3rem}}
-.su-type-6{font-size:2.31em;letter-spacing:-0.020em;}
-@media (min-width: 768px){
-.su-type-6{font-size:2.99em}}
-@media (min-width: 992px){
-.su-type-6{font-size:3.81em}}
 .su-type-5{font-size:2.01em;letter-spacing:-0.018em;}
 @media (min-width: 768px){
 .su-type-5{font-size:2.49em}}
@@ -2401,7 +2383,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-type-1{font-size:1.20em}}
 @media (min-width: 992px){
 .su-type-1{font-size:1.25em}}
-.su-fluid-type-6{font-size:clamp(4.2rem, 4.04vw + 2.75rem, 8.8rem)}
 .su-intro-text{font-size:1.32em;letter-spacing:-0.012em;}
 @media (min-width: 768px){
 .su-intro-text{font-size:1.44em}}
@@ -2435,21 +2416,19 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\!su-absolute{position:absolute !important}
 .su-absolute{position:absolute}
 .su-relative{position:relative}
-.su-sticky{position:sticky}
 .su-inset-0{inset:0}
-.su--bottom-1{bottom:-0.1rem}
 .su--left-80{left:-8rem}
 .su-bottom-0{bottom:0}
 .su-bottom-100{bottom:10rem}
-.su-bottom-120{bottom:12rem}
 .su-bottom-13{bottom:1.3rem}
 .su-bottom-20{bottom:2rem}
 .su-bottom-27{bottom:2.7rem}
 .su-bottom-34{bottom:3.4rem}
 .su-bottom-38{bottom:3.8rem}
 .su-bottom-4{bottom:0.4rem}
-.su-bottom-80{bottom:8rem}
 .su-bottom-\[-100px\]{bottom:-100px}
+.su-bottom-\[13px\]{bottom:13px}
+.su-bottom-\[27px\]{bottom:27px}
 .su-left-0{left:0}
 .su-left-1{left:0.1rem}
 .su-left-1\/2{left:50%}
@@ -2461,7 +2440,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-left-38{left:3.8rem}
 .su-left-8{left:0.8rem}
 .su-left-9{left:0.9rem}
+.su-left-\[13px\]{left:13px}
+.su-left-\[27px\]{left:27px}
+.su-left-\[3px\]{left:3px}
 .su-left-\[50\%\]{left:50%}
+.su-left-\[8px\]{left:8px}
+.su-left-\[9px\]{left:9px}
 .su-right-0{right:0}
 .su-right-1{right:0.1rem}
 .su-right-1\/2{right:50%}
@@ -2471,6 +2455,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-right-48{right:4.8rem}
 .su-right-60{right:6rem}
 .su-right-70{right:7rem}
+.su-right-auto{right:auto}
 .su-top-0{top:0}
 .su-top-1{top:0.1rem}
 .su-top-1\/2{top:50%}
@@ -2485,8 +2470,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-top-9{top:0.9rem}
 .su-top-\[-1\%\]{top:-1%}
 .su-top-\[1\.75em\]{top:1.75em}
+.su-top-\[3px\]{top:3px}
 .su-top-\[50\%\]{top:50%}
+.su-top-\[7px\]{top:7px}
 .su-top-\[80px\]{top:80px}
+.su-top-\[9px\]{top:9px}
 .su-top-auto{top:auto}
 .\!su-z-\[1\]{z-index:1 !important}
 .su-z-0{z-index:0}
@@ -2537,7 +2525,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-my-76{margin-top:7.6rem;margin-bottom:7.6rem}
 .su-my-auto{margin-top:auto;margin-bottom:auto}
 .\!su-mb-0{margin-bottom:0 !important}
-.-su-mt-500{margin-top:-50rem}
+.-su-mt-48{margin-top:-4.8rem}
 .-su-mt-\[16\.2rem\]{margin-top:-16.2rem}
 .su--ml-1em{margin-left:-1em}
 .su--ml-44{margin-left:-4.4rem}
@@ -2545,9 +2533,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su--mt-2{margin-top:-0.2rem}
 .su--mt-50{margin-top:-5rem}
 .su-mb-0{margin-bottom:0}
-.su-mb-01em{margin-bottom:0.1em}
 .su-mb-02em{margin-bottom:0.2em}
-.su-mb-03em{margin-bottom:0.3em}
 .su-mb-10{margin-bottom:1rem}
 .su-mb-11{margin-bottom:1.1rem}
 .su-mb-12{margin-bottom:1.2rem}
@@ -2567,23 +2553,26 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mb-38{margin-bottom:3.8rem}
 .su-mb-41{margin-bottom:4.1rem}
 .su-mb-45{margin-bottom:4.5rem}
-.su-mb-450{margin-bottom:45rem}
 .su-mb-5{margin-bottom:0.5rem}
 .su-mb-58{margin-bottom:5.8rem}
 .su-mb-6{margin-bottom:0.6rem}
 .su-mb-60{margin-bottom:6rem}
-.su-mb-61{margin-bottom:6.1rem}
 .su-mb-8{margin-bottom:0.8rem}
 .su-mb-9{margin-bottom:0.9rem}
 .su-mb-\[-\.5em\]{margin-bottom:-.5em}
 .su-mb-\[-1\.75em\]{margin-bottom:-1.75em}
 .su-mb-\[-3px\]{margin-bottom:-3px}
 .su-mb-\[0px\]{margin-bottom:0px}
+.su-mb-\[13px\]{margin-bottom:13px}
+.su-mb-\[15px\]{margin-bottom:15px}
+.su-mb-\[20px\]{margin-bottom:20px}
 .su-mb-\[3\.2rem\]{margin-bottom:3.2rem}
+.su-mb-\[5px\]{margin-bottom:5px}
 .su-mb-auto{margin-bottom:auto}
 .su-ml-0{margin-left:0}
 .su-ml-04em{margin-left:0.4em}
 .su-ml-05em{margin-left:0.5em}
+.su-ml-06em{margin-left:0.6em}
 .su-ml-1{margin-left:0.1rem}
 .su-ml-13{margin-left:1.3rem}
 .su-ml-19{margin-left:1.9rem}
@@ -2592,9 +2581,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-ml-4{margin-left:0.4rem}
 .su-ml-5{margin-left:0.5rem}
 .su-ml-8{margin-left:0.8rem}
-.su-ml-80{margin-left:8rem}
 .su-ml-\[-\.5rem\]{margin-left:-.5rem}
 .su-ml-\[-3px\]{margin-left:-3px}
+.su-ml-\[-42px\]{margin-left:-42px}
 .su-ml-auto{margin-left:auto}
 .su-mr-0{margin-right:0}
 .su-mr-02em{margin-right:0.2em}
@@ -2619,7 +2608,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mt-19{margin-top:1.9rem}
 .su-mt-2{margin-top:0.2rem}
 .su-mt-20{margin-top:2rem}
-.su-mt-200{margin-top:20rem}
 .su-mt-26{margin-top:2.6rem}
 .su-mt-27{margin-top:2.7rem}
 .su-mt-29{margin-top:2.9rem}
@@ -2643,11 +2631,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mt-\[-63px\]{margin-top:-63px}
 .su-mt-\[-6px\]{margin-top:-6px}
 .su-mt-\[1\.5rem\]{margin-top:1.5rem}
+.su-mt-\[15px\]{margin-top:15px}
 .su-mt-\[23\.65px\]{margin-top:23.65px}
 .su-mt-\[3\.2rem\]{margin-top:3.2rem}
 .su-mt-\[71px\]{margin-top:71px}
+.su-mt-\[9px\]{margin-top:9px}
 .su-mt-auto{margin-top:auto}
-.su-box-border{box-sizing:border-box}
 .su-block{display:block}
 .su-inline-block{display:inline-block}
 .su-inline{display:inline}
@@ -2663,7 +2652,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-size-14{width:1.4rem;height:1.4rem}
 .su-size-150{width:15rem;height:15rem}
 .su-size-16{width:1.6rem;height:1.6rem}
-.su-size-160{width:16rem;height:16rem}
 .su-size-18{width:1.8rem;height:1.8rem}
 .su-size-1em{width:1em;height:1em}
 .su-size-20{width:2rem;height:2rem}
@@ -2679,7 +2667,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-0{height:0}
 .su-h-1{height:0.1rem}
 .su-h-2{height:0.2rem}
-.su-h-20{height:2rem}
 .su-h-21{height:2.1rem}
 .su-h-28{height:2.8rem}
 .su-h-3{height:0.3rem}
@@ -2687,7 +2674,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-35{height:3.5rem}
 .su-h-4{height:0.4rem}
 .su-h-40{height:4rem}
-.su-h-42{height:4.2rem}
 .su-h-43{height:4.3rem}
 .su-h-44{height:4.4rem}
 .su-h-45{height:4.5rem}
@@ -2699,10 +2685,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-72{height:7.2rem}
 .su-h-9{height:0.9rem}
 .su-h-90{height:9rem}
-.su-h-\[100vh\]{height:100vh}
 .su-h-\[101\%\]{height:101%}
+.su-h-\[150px\]{height:150px}
 .su-h-\[165px\]{height:165px}
 .su-h-\[18\.6rem\]{height:18.6rem}
+.su-h-\[200px\]{height:200px}
 .su-h-\[218px\]{height:218px}
 .su-h-\[224px\]{height:224px}
 .su-h-\[233px\]{height:233px}
@@ -2710,8 +2697,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-\[2px\]{height:2px}
 .su-h-\[300px\]{height:300px}
 .su-h-\[34\.2rem\]{height:34.2rem}
+.su-h-\[342px\]{height:342px}
+.su-h-\[4px\]{height:4px}
 .su-h-\[5\.6rem\]{height:5.6rem}
-.su-h-\[56\.25vw\]{height:56.25vw}
+.su-h-\[50px\]{height:50px}
 .su-h-\[56px\]{height:56px}
 .su-h-\[60\%\]{height:60%}
 .su-h-\[66px\]{height:66px}
@@ -2731,7 +2720,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-max-h-70{max-height:7rem}
 .su-max-h-\[103px\]{max-height:103px}
 .su-min-h-\[56px\]{min-height:56px}
-.su-min-h-full{min-height:100%}
 .su-w-08em{width:0.8em}
 .su-w-1{width:0.1rem}
 .su-w-1\/2{width:50%}
@@ -2750,7 +2738,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-w-4{width:0.4rem}
 .su-w-40{width:4rem}
 .su-w-41{width:4.1rem}
-.su-w-42{width:4.2rem}
 .su-w-44{width:4.4rem}
 .su-w-5{width:0.5rem}
 .su-w-5\/6{width:83.333333%}
@@ -2764,13 +2751,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-w-\[10\%\]{width:10%}
 .su-w-\[100\%\]{width:100%}
 .su-w-\[103px\]{width:103px}
+.su-w-\[150px\]{width:150px}
 .su-w-\[16\.66\%\]{width:16.66%}
 .su-w-\[165px\]{width:165px}
-.su-w-\[177\.77777778vh\]{width:177.77777778vh}
+.su-w-\[200px\]{width:200px}
 .su-w-\[218px\]{width:218px}
 .su-w-\[22\.6rem\]{width:22.6rem}
 .su-w-\[224px\]{width:224px}
 .su-w-\[2px\]{width:2px}
+.su-w-\[50px\]{width:50px}
 .su-w-\[56px\]{width:56px}
 .su-w-\[73px\]{width:73px}
 .su-w-\[83\.333\%\]{width:83.333%}
@@ -2786,14 +2775,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-min-w-\[165px\]{min-width:165px}
 .su-min-w-\[218px\]{min-width:218px}
 .su-min-w-\[24\.9rem\]{min-width:24.9rem}
+.su-min-w-\[249px\]{min-width:249px}
 .su-min-w-\[56px\]{min-width:56px}
 .su-min-w-full{min-width:100%}
-.su-max-w-1000{max-width:100rem}
-.su-max-w-1200{max-width:120rem}
 .su-max-w-1500{max-width:150rem}
 .su-max-w-160{max-width:16rem}
 .su-max-w-700{max-width:70rem}
-.su-max-w-800{max-width:80rem}
 .su-max-w-900{max-width:90rem}
 .su-max-w-\[1026px\]{max-width:1026px}
 .su-max-w-\[103px\]{max-width:103px}
@@ -2822,7 +2809,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-grow{flex-grow:1}
 .su-basis-1{flex-basis:0.1rem}
 .su-basis-4{flex-basis:0.4rem}
-.su-basis-auto{flex-basis:auto}
 .-su-translate-x-1{--tw-translate-x:-0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .-su-translate-x-1\/2{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .-su-translate-y-1{--tw-translate-y:-0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -2835,6 +2821,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-translate-x-03em{--tw-translate-x:0.3em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-1em{--tw-translate-x:1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-\[-50\%\]{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-translate-x-\[42px\]{--tw-translate-x:42px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-0{--tw-translate-y:0;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-1{--tw-translate-y:0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-\[-110px\]{--tw-translate-y:-110px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -2844,6 +2831,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rotate-90{--tw-rotate:90deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-rotate-\[-90deg\]{--tw-rotate:-90deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-scale-110{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-transform{transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-cursor-pointer{cursor:pointer}
 .su-list-none{list-style-type:none}
 .su-grid-cols-1{grid-template-columns:repeat(1, minmax(0, 1fr))}
@@ -2888,7 +2876,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-26{gap:2.6rem}
 .su-gap-27{gap:2.7rem}
 .su-gap-29{gap:2.9rem}
-.su-gap-2xl{gap:48px}
 .su-gap-3{gap:0.3rem}
 .su-gap-30{gap:3rem}
 .su-gap-32{gap:3.2rem}
@@ -2897,7 +2884,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-38{gap:3.8rem}
 .su-gap-40{gap:4rem}
 .su-gap-42{gap:4.2rem}
-.su-gap-44{gap:4.4rem}
 .su-gap-45{gap:4.5rem}
 .su-gap-48{gap:4.8rem}
 .su-gap-5{gap:0.5rem}
@@ -2912,10 +2898,20 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-\[0\.6rem\]{gap:0.6rem}
 .su-gap-\[1\.5rem\]{gap:1.5rem}
 .su-gap-\[1\.8rem\]{gap:1.8rem}
+.su-gap-\[10px\]{gap:10px}
+.su-gap-\[11px\]{gap:11px}
 .su-gap-\[18px\]{gap:18px}
+.su-gap-\[19px\]{gap:19px}
 .su-gap-\[2\.1rem\]{gap:2.1rem}
+.su-gap-\[20px\]{gap:20px}
+.su-gap-\[27px\]{gap:27px}
+.su-gap-\[2px\]{gap:2px}
+.su-gap-\[34px\]{gap:34px}
+.su-gap-\[5px\]{gap:5px}
 .su-gap-\[68px\]{gap:68px}
+.su-gap-\[6px\]{gap:6px}
 .su-gap-\[7px\]{gap:7px}
+.su-gap-\[9px\]{gap:9px}
 .su-gap-px{gap:1px}
 .su-gap-x-13{column-gap:1.3rem}
 .su-gap-x-16{column-gap:1.6rem}
@@ -2927,6 +2923,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-x-31{column-gap:3.1em}
 .su-gap-x-40{column-gap:4rem}
 .su-gap-x-\[0\.691rem\]{column-gap:0.691rem}
+.su-gap-x-\[13px\]{column-gap:13px}
 .su-gap-y-0{row-gap:0}
 .su-gap-y-11{row-gap:1.1rem}
 .su-gap-y-12{row-gap:1.2rem}
@@ -2950,7 +2947,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-ellipsis{text-overflow:ellipsis}
 .su-whitespace-nowrap{white-space:nowrap}
 .su-whitespace-pre-line{white-space:pre-line}
-.su-text-balance{text-wrap:balance}
 .su-break-words{overflow-wrap:break-word}
 .su-rounded{border-radius:0.3rem}
 .su-rounded-\[100px\]{border-radius:100px}
@@ -2965,11 +2961,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-border-b{border-bottom-width:1px}
 .su-border-b-2{border-bottom-width:2px}
 .su-border-b-4{border-bottom-width:4px}
-.su-border-l{border-left-width:1px}
 .su-border-l-2{border-left-width:2px}
 .su-border-l-5{border-left-width:5px}
 .su-border-r{border-right-width:1px}
 .su-border-t{border-top-width:1px}
+.su-border-solid{border-style:solid}
 .su-border-none{border-style:none}
 .su-border-black{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
 .su-border-black-10{--tw-border-opacity:1;border-color:rgb(234 234 234 / var(--tw-border-opacity))}
@@ -3010,7 +3006,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bg-gradient-to-l{background-image:linear-gradient(to left, var(--tw-gradient-stops))}
 .su-bg-gradient-to-r{background-image:linear-gradient(to right, var(--tw-gradient-stops))}
 .su-bg-gradient-to-t{background-image:linear-gradient(to top, var(--tw-gradient-stops))}
-.su-from-black{--tw-gradient-from:#2E2D29 var(--tw-gradient-from-position);--tw-gradient-to:rgb(46 45 41 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-black-true{--tw-gradient-from:#000000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-black-true\/75{--tw-gradient-from:rgb(0 0 0 / 0.75) var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-black-true\/80{--tw-gradient-from:rgb(0 0 0 / 0.8) var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
@@ -3031,7 +3026,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-to-digital-red-light{--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
 .su-to-olive{--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
 .su-to-plum{--tw-gradient-to:#620059 var(--tw-gradient-to-position)}
-.su-to-transparent{--tw-gradient-to:transparent var(--tw-gradient-to-position)}
 .su-to-50\%{--tw-gradient-to-position:50%}
 .su-bg-cover{background-size:cover}
 .su-bg-center{background-position:center}
@@ -3063,6 +3057,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-p-48{padding:4.8rem}
 .su-p-7{padding:0.7rem}
 .su-p-9{padding:0.9rem}
+.su-p-\[3px\]{padding:3px}
+.su-p-\[7px\]{padding:7px}
+.su-p-\[9px\]{padding:9px}
 .su-px-0{padding-left:0;padding-right:0}
 .su-px-20{padding-left:2rem;padding-right:2rem}
 .su-px-22{padding-left:2.2rem;padding-right:2.2rem}
@@ -3077,6 +3074,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-px-5{padding-left:0.5rem;padding-right:0.5rem}
 .su-px-50{padding-left:5rem;padding-right:5rem}
 .su-px-65{padding-left:6.5rem;padding-right:6.5rem}
+.su-px-\[20px\]{padding-left:20px;padding-right:20px}
 .su-py-0{padding-top:0;padding-bottom:0}
 .su-py-10{padding-top:1rem;padding-bottom:1rem}
 .su-py-15{padding-top:1.5rem;padding-bottom:1.5rem}
@@ -3123,7 +3121,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pl-15{padding-left:1.5rem}
 .su-pl-170{padding-left:17rem}
 .su-pl-20{padding-left:2rem}
-.su-pl-200{padding-left:20rem}
 .su-pl-25{padding-left:2.5rem}
 .su-pl-27{padding-left:2.7rem}
 .su-pl-30{padding-left:3rem}
@@ -3132,6 +3129,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pl-39{padding-left:3.9rem}
 .su-pl-48{padding-left:4.8rem}
 .su-pl-50{padding-left:5rem}
+.su-pl-\[39px\]{padding-left:39px}
 .su-pl-\[calc\(16\.666\%\+10px\)\]{padding-left:calc(16.666% + 10px)}
 .su-pr-0{padding-right:0}
 .su-pr-10{padding-right:1rem}
@@ -3197,15 +3195,21 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-\[1\.5rem\]{font-size:1.5rem}
 .su-text-\[1\.8rem\]{font-size:1.8rem}
 .su-text-\[14px\]{font-size:14px}
+.su-text-\[16px\]{font-size:16px}
+.su-text-\[18px\]{font-size:18px}
+.su-text-\[19px\]{font-size:19px}
 .su-text-\[2\.0rem\]{font-size:2.0rem}
 .su-text-\[2\.4rem\]{font-size:2.4rem}
+.su-text-\[20px\]{font-size:20px}
+.su-text-\[21px\]{font-size:21px}
+.su-text-\[24px\]{font-size:24px}
+.su-text-\[28px\]{font-size:28px}
 .su-text-\[3\.5rem\]{font-size:3.5rem}
 .su-text-\[3\.6rem\]{font-size:3.6rem}
 .su-text-\[33px\]{font-size:33px}
 .su-text-\[35px\]{font-size:35px}
 .su-text-\[39px\]{font-size:39px}
 .su-text-\[3rem\]{font-size:3rem}
-.su-text-\[4\.5rem\]{font-size:4.5rem}
 .su-text-\[4\.6rem\]{font-size:4.6rem}
 .su-text-\[4\.8rem\]{font-size:4.8rem}
 .su-text-\[40px\]{font-size:40px}
@@ -3229,10 +3233,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-leading-\[1\.6rem\]{line-height:1.6rem}
 .su-leading-\[119\.4\%\]{line-height:119.4%}
 .su-leading-\[119\.415\%\]{line-height:119.415%}
+.su-leading-\[120\%\]{line-height:120%}
 .su-leading-\[125\%\]{line-height:125%}
 .su-leading-\[125\.28\%\]{line-height:125.28%}
 .su-leading-\[130\%\]{line-height:130%}
 .su-leading-\[130\.245\%\]{line-height:130.245%}
+.su-leading-\[150\%\]{line-height:150%}
 .su-leading-\[16\.72px\]{line-height:16.72px}
 .su-leading-\[16px\]{line-height:16px}
 .su-leading-\[17\.5px\]{line-height:17.5px}
@@ -3277,6 +3283,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-leading-tight{line-height:1.1}
 .su-tracking-normal{letter-spacing:0em}
 .\!su-text-digital-red{--tw-text-opacity:1 !important;color:rgb(177 4 14 / var(--tw-text-opacity)) !important}
+.su-text-\[white\]{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .su-text-black{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
 .su-text-black-40{--tw-text-opacity:1;color:rgb(171 171 169 / var(--tw-text-opacity))}
 .su-text-black-50{--tw-text-opacity:1;color:rgb(151 150 148 / var(--tw-text-opacity))}
@@ -3296,10 +3303,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-no-underline{text-decoration-line:none}
 .su-decoration-dark-mode-red{text-decoration-color:#EC0909}
 .su-decoration-2{text-decoration-thickness:2px}
-.su-decoration-\[0\.12em\]{text-decoration-thickness:0.12em}
 .su-decoration-\[3px\]{text-decoration-thickness:3px}
 .su-underline-offset-4{text-underline-offset:4px}
-.su-underline-offset-\[3px\]{text-underline-offset:3px}
 .su-opacity-0{opacity:0}
 .su-opacity-100{opacity:1}
 .su-opacity-25{opacity:0.25}
@@ -4028,11 +4033,14 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .before\:su--mt-25::before{content:var(--tw-content);margin-top:-2.5rem}
 .before\:su--mt-30::before{content:var(--tw-content);margin-top:-3rem}
 .before\:su-mr-6::before{content:var(--tw-content);margin-right:0.6rem}
+.before\:su-mr-\[6px\]::before{content:var(--tw-content);margin-right:6px}
+.before\:su-mt-\[-25px\]::before{content:var(--tw-content);margin-top:-25px}
 .before\:su-block::before{content:var(--tw-content);display:block}
 .before\:su-h-1::before{content:var(--tw-content);height:0.1rem}
 .before\:su-h-15::before{content:var(--tw-content);height:1.5rem}
 .before\:su-h-2::before{content:var(--tw-content);height:0.2rem}
 .before\:su-h-4::before{content:var(--tw-content);height:0.4rem}
+.before\:su-h-\[1px\]::before{content:var(--tw-content);height:1px}
 .before\:su-h-\[4\.5px\]::before{content:var(--tw-content);height:4.5px}
 .before\:su-h-full::before{content:var(--tw-content);height:100%}
 .before\:su-h-px::before{content:var(--tw-content);height:1px}
@@ -4126,10 +4134,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .aria-pressed\:su-bg-transparent[aria-pressed="true"]{background-color:transparent}
 .aria-pressed\:su-text-white[aria-pressed="true"]{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .su-group\/front[aria-hidden="true"] .group-aria-hidden\/front\:su-opacity-0{opacity:0}
-.hocus\:su-scale-110:hover{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
-@keyframes su-pulse{
-50%{opacity:.5}}
-.hocus\:su-animate-pulse:hover{animation:su-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite}
 .hocus\:su-border-black:hover{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
 .hocus\:su-border-digital-blue-vivid:hover{--tw-border-opacity:1;border-color:rgb(5 151 255 / var(--tw-border-opacity))}
 .hocus\:su-border-digital-green-bright:hover{--tw-border-opacity:1;border-color:rgb(0 155 118 / var(--tw-border-opacity))}
@@ -4140,7 +4144,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .hocus\:su-bg-digital-red:hover{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
 .hocus\:su-bg-none:hover{background-image:none}
 .hocus\:su-text-black:hover{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-.hocus\:su-text-dark-mode-red:hover{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .hocus\:su-text-digital-red:hover{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .hocus\:su-text-white:hover{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .hocus\:su-text-white\/95:hover{color:rgb(255 255 255 / 0.95)}
@@ -4148,10 +4151,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .hocus\:su-no-underline:hover{text-decoration-line:none}
 .hocus\:su-decoration-white:hover{text-decoration-color:#fff}
 .hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(177\2c 4\2c 14\2c 1\)\]:hover{--tw-shadow:inset 0 0 0 3px rgba(177,4,14,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
-.hocus\:su-scale-110:focus{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
-@keyframes su-pulse{
-50%{opacity:.5}}
-.hocus\:su-animate-pulse:focus{animation:su-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite}
 .hocus\:su-border-black:focus{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
 .hocus\:su-border-digital-blue-vivid:focus{--tw-border-opacity:1;border-color:rgb(5 151 255 / var(--tw-border-opacity))}
 .hocus\:su-border-digital-green-bright:focus{--tw-border-opacity:1;border-color:rgb(0 155 118 / var(--tw-border-opacity))}
@@ -4162,7 +4161,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .hocus\:su-bg-digital-red:focus{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
 .hocus\:su-bg-none:focus{background-image:none}
 .hocus\:su-text-black:focus{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-.hocus\:su-text-dark-mode-red:focus{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .hocus\:su-text-digital-red:focus{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .hocus\:su-text-white:focus{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .hocus\:su-text-white\/95:focus{color:rgb(255 255 255 / 0.95)}
@@ -4389,9 +4387,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-mb-30{margin-bottom:3rem}
 .md\:su-mb-60{margin-bottom:6rem}
 .md\:su-mb-8{margin-bottom:0.8rem}
+.md\:su-mb-\[11px\]{margin-bottom:11px}
+.md\:su-mb-\[18px\]{margin-bottom:18px}
+.md\:su-mb-\[19px\]{margin-bottom:19px}
+.md\:su-mb-\[26px\]{margin-bottom:26px}
+.md\:su-mb-\[27px\]{margin-bottom:27px}
 .md\:su-mb-\[3px\]{margin-bottom:3px}
 .md\:su-mb-\[5\.9rem\]{margin-bottom:5.9rem}
 .md\:su-mb-\[6\.05px\]{margin-bottom:6.05px}
+.md\:su-mb-\[8px\]{margin-bottom:8px}
 .md\:su-ml-19{margin-left:1.9rem}
 .md\:su-ml-\[19px\]{margin-left:19px}
 .md\:su-ml-\[8\.333\%\]{margin-left:8.333%}
@@ -4408,6 +4412,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-mt-26{margin-top:2.6rem}
 .md\:su-mt-61{margin-top:6.1rem}
 .md\:su-mt-\[1\.9rem\]{margin-top:1.9rem}
+.md\:su-mt-\[12px\]{margin-top:12px}
+.md\:su-mt-\[26px\]{margin-top:26px}
 .md\:su-mt-\[4\.8rem\]{margin-top:4.8rem}
 .md\:su-mt-auto{margin-top:auto}
 .md\:su-block{display:block}
@@ -4415,7 +4421,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-flex{display:flex}
 .md\:su-grid{display:grid}
 .md\:su-hidden{display:none}
-.md\:su-size-200{width:20rem;height:20rem}
 .md\:su-size-50{width:5rem;height:5rem}
 .md\:su-size-70{width:7rem;height:7rem}
 .md\:su-h-3{height:0.3rem}
@@ -4428,6 +4433,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-max-h-\[168px\]{max-height:168px}
 .md\:su-max-h-\[6em\]{max-height:6em}
 .md\:su-min-h-\[38\.4rem\]{min-height:38.4rem}
+.md\:su-min-h-\[384px\]{min-height:384px}
 .md\:su-w-1\/3{width:33.333333%}
 .md\:su-w-3{width:0.3rem}
 .md\:su-w-30{width:3rem}
@@ -4449,6 +4455,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-w-auto{width:auto}
 .md\:su-min-w-\[170px\]{min-width:170px}
 .md\:su-min-w-\[17rem\]{min-width:17rem}
+.md\:su-min-w-\[249px\]{min-width:249px}
 .md\:su-min-w-\[257px\]{min-width:257px}
 .md\:su-max-w-500{max-width:50rem}
 .md\:su-max-w-\[168px\]{max-width:168px}
@@ -4488,8 +4495,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-gap-61{gap:6.1rem}
 .md\:su-gap-72{gap:7.2rem}
 .md\:su-gap-9{gap:0.9rem}
+.md\:su-gap-\[0px\]{gap:0px}
+.md\:su-gap-\[12px\]{gap:12px}
 .md\:su-gap-\[13px\]{gap:13px}
 .md\:su-gap-\[2\.5rem\]{gap:2.5rem}
+.md\:su-gap-\[36px\]{gap:36px}
+.md\:su-gap-\[48px\]{gap:48px}
+.md\:su-gap-\[72px\]{gap:72px}
 .md\:su-gap-x-20{column-gap:2rem}
 .md\:su-gap-x-24{column-gap:2.4rem}
 .md\:su-gap-x-27{column-gap:2.7rem}
@@ -4536,6 +4548,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pb-9{padding-bottom:0.9rem}
 .md\:su-pb-\[1\.3rem\]{padding-bottom:1.3rem}
 .md\:su-pb-\[10px\]{padding-bottom:10px}
+.md\:su-pb-\[13px\]{padding-bottom:13px}
 .md\:su-pb-\[14px\]{padding-bottom:14px}
 .md\:su-pb-\[16\.6rem\]{padding-bottom:16.6rem}
 .md\:su-pb-\[17\.7rem\]{padding-bottom:17.7rem}
@@ -4543,8 +4556,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pb-\[20\.05px\]{padding-bottom:20.05px}
 .md\:su-pb-\[6\.05px\]{padding-bottom:6.05px}
 .md\:su-pb-\[64px\]{padding-bottom:64px}
+.md\:su-pb-\[9px\]{padding-bottom:9px}
 .md\:su-pl-0{padding-left:0}
-.md\:su-pl-48{padding-left:4.8rem}
 .md\:su-pl-50{padding-left:5rem}
 .md\:su-pl-76{padding-left:7.6rem}
 .md\:su-pr-0{padding-right:0}
@@ -4576,15 +4589,20 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-text-\[1\.9rem\]{font-size:1.9rem}
 .md\:su-text-\[10rem\]{font-size:10rem}
 .md\:su-text-\[16px\]{font-size:16px}
+.md\:su-text-\[19px\]{font-size:19px}
 .md\:su-text-\[2\.9rem\]{font-size:2.9rem}
+.md\:su-text-\[20px\]{font-size:20px}
+.md\:su-text-\[21px\]{font-size:21px}
+.md\:su-text-\[28px\]{font-size:28px}
 .md\:su-text-\[3\.3rem\]{font-size:3.3rem}
 .md\:su-text-\[3\.6rem\]{font-size:3.6rem}
+.md\:su-text-\[35px\]{font-size:35px}
+.md\:su-text-\[36px\]{font-size:36px}
 .md\:su-text-\[4\.0rem\]{font-size:4.0rem}
 .md\:su-text-\[40px\]{font-size:40px}
 .md\:su-text-\[4rem\]{font-size:4rem}
 .md\:su-text-\[54px\]{font-size:54px}
 .md\:su-text-\[7\.2rem\]{font-size:7.2rem}
-.md\:su-text-\[7\.5rem\]{font-size:7.5rem}
 .md\:su-text-\[80px\]{font-size:80px}
 .md\:su-font-normal{font-weight:400}
 .md\:su-leading-\[1\.911rem\]{line-height:1.911rem}
@@ -4636,6 +4654,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .before\:md\:su-h-full::before{content:var(--tw-content);height:100%}
 .md\:before\:su-h-full::before{content:var(--tw-content);height:100%}
 .before\:md\:su-w-1::before{content:var(--tw-content);width:0.1rem}
+.before\:md\:su-w-\[1px\]::before{content:var(--tw-content);width:1px}
 .before\:md\:su-w-full::before{content:var(--tw-content);width:100%}
 .before\:md\:su-w-px::before{content:var(--tw-content);width:1px}
 .md\:before\:su-w-\[26\%\]::before{content:var(--tw-content);width:26%}
@@ -4687,7 +4706,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-mb-8{margin-bottom:0.8rem}
 .lg\:su-mb-9{margin-bottom:0.9rem}
 .lg\:su-mb-\[104px\]{margin-bottom:104px}
+.lg\:su-mb-\[12px\]{margin-bottom:12px}
+.lg\:su-mb-\[15px\]{margin-bottom:15px}
+.lg\:su-mb-\[19px\]{margin-bottom:19px}
 .lg\:su-mb-\[2\.25px\]{margin-bottom:2.25px}
+.lg\:su-mb-\[38px\]{margin-bottom:38px}
 .lg\:su-mb-\[4px\]{margin-bottom:4px}
 .lg\:su-ml-0{margin-left:0}
 .lg\:su-ml-26{margin-left:2.6rem}
@@ -4715,6 +4738,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-mt-\[-131px\]{margin-top:-131px}
 .lg\:su-mt-\[0px\]{margin-top:0px}
 .lg\:su-mt-\[19\.5px\]{margin-top:19.5px}
+.lg\:su-mt-\[29px\]{margin-top:29px}
 .lg\:su-block{display:block}
 .lg\:su-inline-block{display:inline-block}
 .lg\:su-flex{display:flex}
@@ -4725,9 +4749,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-h-9{height:0.9rem}
 .lg\:su-h-\[193px\]{height:193px}
 .lg\:su-h-\[292px\]{height:292px}
+.lg\:su-h-\[373px\]{height:373px}
 .lg\:su-h-\[378\.331px\]{height:378.331px}
 .lg\:su-h-\[4px\]{height:4px}
 .lg\:su-h-\[57\.2rem\]{height:57.2rem}
+.lg\:su-h-\[572px\]{height:572px}
 .lg\:su-h-\[764px\]{height:764px}
 .lg\:su-h-\[871\.33px\]{height:871.33px}
 .lg\:su-h-\[calc\(100\%\+15\.5rem\+1em\)\]{height:calc(100% + 15.5rem + 1em)}
@@ -4749,6 +4775,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-w-\[calc\(50\%-1\.9rem\)\]{width:calc(50% - 1.9rem)}
 .lg\:su-w-full{width:100%}
 .lg\:su-min-w-\[38\.2rem\]{min-width:38.2rem}
+.lg\:su-min-w-\[382px\]{min-width:382px}
 .lg\:su-max-w-800{max-width:80rem}
 .lg\:su-max-w-\[185px\]{max-width:185px}
 .lg\:su-max-w-\[29\.2rem\]{max-width:29.2rem}
@@ -4756,6 +4783,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-max-w-\[296px\]{max-width:296px}
 .lg\:su-max-w-\[35\.9rem\]{max-width:35.9rem}
 .lg\:su-max-w-\[38\.2rem\]{max-width:38.2rem}
+.lg\:su-max-w-\[382px\]{max-width:382px}
 .lg\:su-max-w-\[50\%\]{max-width:50%}
 .lg\:su-max-w-\[63\.6rem\]{max-width:63.6rem}
 .lg\:su-max-w-\[633px\]{max-width:633px}
@@ -4771,7 +4799,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-grid-cols-3{grid-template-columns:repeat(3, minmax(0, 1fr))}
 .lg\:su-grid-cols-4{grid-template-columns:repeat(4, minmax(0, 1fr))}
 .lg\:su-flex-row{flex-direction:row}
-.lg\:su-flex-row-reverse{flex-direction:row-reverse}
 .lg\:su-flex-col{flex-direction:column}
 .lg\:su-flex-wrap{flex-wrap:wrap}
 .lg\:su-flex-nowrap{flex-wrap:nowrap}
@@ -4793,9 +4820,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-gap-61{gap:6.1rem}
 .lg\:su-gap-9{gap:0.9rem}
 .lg\:su-gap-\[102px\]{gap:102px}
+.lg\:su-gap-\[12px\]{gap:12px}
+.lg\:su-gap-\[13px\]{gap:13px}
 .lg\:su-gap-\[160px\]{gap:160px}
 .lg\:su-gap-\[36px\]{gap:36px}
+.lg\:su-gap-\[48px\]{gap:48px}
 .lg\:su-gap-\[76px\]{gap:76px}
+.lg\:su-gap-\[9px\]{gap:9px}
 .lg\:su-gap-x-20{column-gap:2rem}
 .lg\:su-gap-x-27{column-gap:2.7rem}
 .lg\:su-gap-x-40{column-gap:4rem}
@@ -4818,6 +4849,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-py-30{padding-top:3rem;padding-bottom:3rem}
 .lg\:su-py-36{padding-top:3.6rem;padding-bottom:3.6rem}
 .lg\:su-py-61{padding-top:6.1rem;padding-bottom:6.1rem}
+.lg\:su-py-\[30px\]{padding-top:30px;padding-bottom:30px}
 .lg\:su-pb-0{padding-bottom:0}
 .lg\:su-pb-16{padding-bottom:1.6rem}
 .lg\:su-pb-27{padding-bottom:2.7rem}
@@ -4857,14 +4889,21 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-text-23{font-size:2.3rem}
 .lg\:su-text-24{font-size:2.4rem}
 .lg\:su-text-\[128px\]{font-size:128px}
+.lg\:su-text-\[16px\]{font-size:16px}
+.lg\:su-text-\[18px\]{font-size:18px}
 .lg\:su-text-\[2\.1rem\]{font-size:2.1rem}
 .lg\:su-text-\[2\.8rem\]{font-size:2.8rem}
+.lg\:su-text-\[20px\]{font-size:20px}
+.lg\:su-text-\[21px\]{font-size:21px}
+.lg\:su-text-\[23px\]{font-size:23px}
+.lg\:su-text-\[24px\]{font-size:24px}
 .lg\:su-text-\[3\.6rem\]{font-size:3.6rem}
 .lg\:su-text-\[32px\]{font-size:32px}
 .lg\:su-text-\[33px\]{font-size:33px}
 .lg\:su-text-\[4\.3rem\]{font-size:4.3rem}
 .lg\:su-text-\[4\.9rem\]{font-size:4.9rem}
 .lg\:su-text-\[43px\]{font-size:43px}
+.lg\:su-text-\[48px\]{font-size:48px}
 .lg\:su-text-\[70px\]{font-size:70px}
 .lg\:su-text-\[9\.5rem\]{font-size:9.5rem}
 .lg\:su-text-\[9\.6rem\]{font-size:9.6rem}
@@ -4910,6 +4949,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:before\:su--mt-32::before{content:var(--tw-content);margin-top:-3.2rem}
 .lg\:before\:su--mt-38::before{content:var(--tw-content);margin-top:-3.8rem}
 .lg\:before\:su-mr-13::before{content:var(--tw-content);margin-right:1.3rem}
+.lg\:before\:su-mr-\[13px\]::before{content:var(--tw-content);margin-right:13px}
+.lg\:before\:su-mt-\[-38px\]::before{content:var(--tw-content);margin-top:-38px}
 .before\:lg\:su-h-full::before{content:var(--tw-content);height:100%}
 .lg\:before\:su-h-full::before{content:var(--tw-content);height:100%}
 .lg\:before\:su-h-px::before{content:var(--tw-content);height:1px}
@@ -4957,9 +4998,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\32xl\:su-bottom-61{bottom:6.1rem}
 .\32xl\:su-left-48{left:4.8rem}
 .\32xl\:su--mt-58{margin-top:-5.8rem}
-.\32xl\:su-ml-80{margin-left:8rem}
 .\32xl\:su-mt-171{margin-top:17.1rem}
-.\32xl\:su-size-300{width:30rem;height:30rem}
 .\32xl\:su-basis-\[30\%\]{flex-basis:30%}
 .\32xl\:su-basis-\[70\%\]{flex-basis:70%}
 .\32xl\:su-flex-row{flex-direction:row}
@@ -4968,7 +5007,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\32xl\:su-px-\[17rem\]{padding-left:17rem;padding-right:17rem}
 .\32xl\:su-px-\[6\.6rem\]{padding-left:6.6rem;padding-right:6.6rem}
 .\32xl\:su-py-140{padding-top:14rem;padding-bottom:14rem}
-.\32xl\:su-pl-200{padding-left:20rem}
 .\32xl\:su-pl-76{padding-left:7.6rem}
 .\32xl\:su-text-\[2\.9rem\]{font-size:2.9rem}
 .\32xl\:su-text-\[3\.3rem\]{font-size:3.3rem}
@@ -4976,17 +5014,39 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\[\&\>\*\:last-child\]\:su-mb-0>*:last-child{margin-bottom:0}
 .\[\&\>\*\:last-child\]\:after\:su-content-\[\'\\u201D\'\]>*:last-child::after{--tw-content:'\u201D';content:var(--tw-content)}
 .\[\&\>\*\:last-child\]\:after\:su-content-\[\'\201D\'\]>*:last-child::after{--tw-content:'”';content:var(--tw-content)}
+.\[\&\>\*\]\:su-my-0>*{margin-top:0;margin-bottom:0}
+.\[\&\>\*\]\:su-mt-\[4px\]>*{margin-top:4px}
 .\[\&\>\*\]\:su-inline-block>*{display:inline-block}
 .\[\&\>\*\]\:su-h-23>*{height:2.3rem}
+.\[\&\>\*\]\:su-h-\[42px\]>*{height:42px}
 .\[\&\>\*\]\:su-w-24>*{width:2.4rem}
+.\[\&\>\*\]\:su-w-\[42px\]>*{width:42px}
+.\[\&\>\*\]\:su-w-full>*{width:100%}
 .\[\&\>\*\]\:su-translate-x-\[\.12em\]>*{--tw-translate-x:.12em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>\*\]\:su-translate-y-\[-\.08em\]>*{--tw-translate-y:-.08em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>\*\]\:su-rotate-\[-45deg\]>*{--tw-rotate:-45deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>\*\]\:su-justify-center>*{justify-content:center}
+.\[\&\>\*\]\:su-fill-transparent>*{fill:transparent}
 .\[\&\>\*\]\:su-stroke-current>*{stroke:currentColor}
 .\[\&\>\*\]\:su-stroke-digital-red>*{stroke:#B1040E}
+.\[\&\>\*\]\:su-font-sans>*{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif}
+.\[\&\>\*\]\:su-text-\[18px\]>*{font-size:18px}
+.\[\&\>\*\]\:su-text-\[19px\]>*{font-size:19px}
 .\[\&\>\*\]\:su-font-bold>*{font-weight:700}
+.\[\&\>\*\]\:su-font-normal>*{font-weight:400}
+.\[\&\>\*\]\:su-leading-\[125\%\]>*{line-height:125%}
+.\[\&\>\*\]\:su-leading-\[130\%\]>*{line-height:130%}
+.\[\&\>\*\]\:su-leading-\[22\.5px\]>*{line-height:22.5px}
+.\[\&\>\*\]\:su-leading-\[23\.75px\]>*{line-height:23.75px}
 :is(.su-dark .dark\:\[\&\>\*\]\:su-stroke-dark-mode-red>*){stroke:#EC0909}
+:is(.su-dark .\[\&\>\*\]\:dark\:su-text-white)>*{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+@media (min-width: 768px){
+.\[\&\>\*\]\:md\:su-mt-\[14px\]>*{margin-top:14px}
+.\[\&\>\*\]\:md\:su-text-\[19px\]>*{font-size:19px}
+.md\:\[\&\>\*\]\:su-text-\[19px\]>*{font-size:19px}
+.\[\&\>\*\]\:md\:su-leading-\[23\.75px\]>*{line-height:23.75px}}
+@media (min-width: 992px){
+.lg\:\[\&\>\*\]\:su-text-\[21px\]>*{font-size:21px}}
 .\[\&\>li\]\:su-m-0>li{margin:0}
 .\[\&\>p\]\:su-m-0>p{margin:0}
 .\[\&\>p\]\:\!su-mb-0>p{margin-bottom:0 !important}
@@ -4996,13 +5056,17 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:\[\&\>p\]\:\!su-text-19>p{font-size:1.9rem !important}}
 .\[\&\>svg\]\:su-mt-3>svg{margin-top:0.3rem}
 .\[\&\>svg\]\:su-h-43>svg{height:4.3rem}
+.\[\&\>svg\]\:su-h-\[40px\]>svg{height:40px}
 .\[\&\>svg\]\:su-w-41>svg{width:4.1rem}
+.\[\&\>svg\]\:su-w-\[40px\]>svg{width:40px}
 .\[\&\>svg\]\:su-translate-y-1>svg{--tw-translate-y:0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>svg\]\:su-text-\[4rem\]>svg{font-size:4rem}
 .\[\&\>svg\]\:su-text-\[6rem\]>svg{font-size:6rem}
 @media (min-width: 768px){
 .md\:\[\&\>svg\]\:su--mt-2>svg{margin-top:-0.2rem}
+.\[\&\>svg\]\:md\:su-h-\[60px\]>svg{height:60px}
 .md\:\[\&\>svg\]\:su-h-\[102px\]>svg{height:102px}
+.\[\&\>svg\]\:md\:su-w-\[60px\]>svg{width:60px}
 .md\:\[\&\>svg\]\:su-w-\[97px\]>svg{width:97px}
 .\[\&\>svg\]\:md\:su-text-\[6rem\]>svg{font-size:6rem}}
 @media (min-width: 992px){

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -643,7 +643,7 @@ h6{font-family:"Source Serif 4","Source Serif Pro",Georgia,Times,"Times New Roma
 .component-slider-cards{margin-left:0;margin-right:0}}
 .component-slider .swiper-slide > *{transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .component-slider-peek .swiper-slide-prev > *,
-.component-slider-peek .swiper-slide-next > *{pointer-events:none;opacity:.27}
+.component-slider-peek .swiper-slide-next > *{pointer-events:none;opacity:0.25}
 @media (min-width: 768px){
 .component-slider-peek .swiper-slide-prev > *,
 .component-slider-peek .swiper-slide-next > *{pointer-events:auto;opacity:1}}
@@ -656,14 +656,37 @@ h6{font-family:"Source Serif 4","Source Serif Pro",Georgia,Times,"Times New Roma
 @media (min-width: 768px){
 .component-slider-cards.component-slider-peek{margin-left:0;margin-right:0}}
 .component-slider-single.component-slider-peek .swiper-slide-prev > *,
-.component-slider-single.component-slider-peek .swiper-slide-next > *{pointer-events:none;opacity:.27}
+.component-slider-single.component-slider-peek .swiper-slide-next > *{pointer-events:none;opacity:0.25}
 @media (min-width: 768px){
 .component-slider-single.component-slider-peek .swiper-slide-prev > *,
 .component-slider-single.component-slider-peek .swiper-slide-next > *{pointer-events:auto;opacity:1}}
+.component-slider-single.component-slider-peek.component-slider-vertical-videos .swiper-slide-prev > *,
+.component-slider-single.component-slider-peek.component-slider-vertical-videos .swiper-slide-next > *{pointer-events:none;opacity:0.25}
+.su-slider-dark .component-slider-single.component-slider-peek.component-slider-vertical-videos .swiper-slide-prev > *,
+.su-slider-dark .component-slider-single.component-slider-peek.component-slider-vertical-videos .swiper-slide-next > *{pointer-events:none;opacity:0.4}
 .component-slider .component-slider-pagination{position:static;display:flex;gap:1rem;text-align:left}
-.component-slider .swiper-pagination-bullet{margin-left:0;margin-right:0;height:2rem;width:2rem;border-width:2px;border-style:solid;--tw-border-opacity:1;border-color:rgb(192 192 191 / var(--tw-border-opacity));background-color:transparent;opacity:1;transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
+.component-slider .swiper-pagination-bullet{margin-left:0;margin-right:0;height:2rem;width:2rem;border-width:2px;border-style:solid;--tw-border-opacity:1;border-color:rgb(171 171 169 / var(--tw-border-opacity));background-color:transparent;opacity:1;transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 :is(.su-dark .component-slider .swiper-pagination-bullet){--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity))}
 .component-slider.su-slider-dark .swiper-pagination-bullet{margin-left:0;margin-right:0;height:2rem;width:2rem;border-width:2px;border-style:solid;--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity));background-color:transparent;opacity:1;transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
+.component-slider .component-slider-vertical-videos + .component-slider-controls{padding-left:20px;padding-right:20px;margin-left:auto;margin-right:auto;}
+@media (min-width: 576px){
+.component-slider .component-slider-vertical-videos + .component-slider-controls{padding-left:30px;padding-right:30px}}
+@media (min-width: 768px){
+.component-slider .component-slider-vertical-videos + .component-slider-controls{padding-left:50px;padding-right:50px}}
+@media (min-width: 992px){
+.component-slider .component-slider-vertical-videos + .component-slider-controls{padding-left:80px;padding-right:80px}}
+@media (min-width: 1200px){
+.component-slider .component-slider-vertical-videos + .component-slider-controls{padding-left:100px;padding-right:100px}}
+@media (min-width: 1500px){
+.component-slider .component-slider-vertical-videos + .component-slider-controls{padding-left:100px;padding-right:100px}}
+@media only screen and (min-width: 1700px){
+.component-slider .component-slider-vertical-videos + .component-slider-controls{padding-left:calc((100% - 1500px)/2);padding-right:calc((100% - 1500px)/2)}}
+ .su-centered-container .component-slider .component-slider-vertical-videos + .component-slider-controls,.component-slider .component-slider-vertical-videos + .component-slider-controls .su-centered-container,.component-slider .component-slider-vertical-videos + .component-slider-controls .su-cc{padding-left:0;padding-right:0}
+.component-slider.su-slider-dark .component-slider-vertical-videos + .component-slider-controls .swiper-pagination-bullet{border-width:2px;--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity))}
+.component-slider.su-slider-dark .component-slider-vertical-videos + .component-slider-controls .swiper-pagination-bullet:hover{--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+.component-slider.su-slider-dark .component-slider-vertical-videos + .component-slider-controls .swiper-pagination-bullet:focus-visible{--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+.component-slider.su-slider-dark .component-slider-vertical-videos + .component-slider-controls .swiper-pagination-bullet:active{--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+.component-slider.su-slider-dark .component-slider-vertical-videos + .component-slider-controls .swiper-pagination-bullet.swiper-pagination-bullet-active{--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
 .component-slider .swiper-pagination-lock{pointer-events:none}
 .component-slider .swiper-pagination-horizontal.component-slider-pagination{flex-wrap:wrap}
 .component-slider
@@ -672,12 +695,15 @@ h6{font-family:"Source Serif 4","Source Serif Pro",Georgia,Times,"Times New Roma
   --swiper-pagination-bullet-horizontal-gap: 0;
   margin: 0 !important;
 }
-.component-slider.su-slider-dark .swiper-pagination-bullet:hover,
+.component-slider.su-slider-dark .swiper-pagination-bullet:hover{--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+.component-slider.su-slider-dark .swiper-pagination-bullet:focus-visible{--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
 .component-slider.su-slider-dark .swiper-pagination-bullet:active{--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
-.component-slider .swiper-pagination-bullet:hover,
+.component-slider .swiper-pagination-bullet:hover{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
+.component-slider .swiper-pagination-bullet:focus-visible{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
 .component-slider .swiper-pagination-bullet:active{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
-:is(.su-dark .component-slider .swiper-pagination-bullet:hover),:is(.su-dark 
-.component-slider .swiper-pagination-bullet:active){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .component-slider .swiper-pagination-bullet:hover){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .component-slider .swiper-pagination-bullet:focus-visible){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .component-slider .swiper-pagination-bullet:active){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
 .component-slider .swiper-pagination-bullet.swiper-pagination-bullet-active{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
 :is(.su-dark .component-slider .swiper-pagination-bullet.swiper-pagination-bullet-active){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
 .component-slider.su-slider-dark
@@ -693,13 +719,17 @@ h6{font-family:"Source Serif 4","Source Serif Pro",Georgia,Times,"Times New Roma
 .component-slider .component-slider-prev svg{--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .component-slider .component-slider-btn{position:relative;top:auto;bottom:0;height:3.7rem;min-width:3.7rem;max-width:3.7rem;border-radius:9999px;border-width:2px;--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity));transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .component-slider .component-slider-btn:hover{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.component-slider .component-slider-btn:focus{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+.component-slider .component-slider-btn:focus-visible{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 :is(.su-dark .component-slider .component-slider-btn){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
-:is(.su-dark .component-slider .component-slider-btn:hover){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-:is(.su-dark .component-slider .component-slider-btn:focus){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.component-slider.su-slider-dark .component-slider-btn{position:relative;top:auto;bottom:0;height:37px;min-width:37px;max-width:37px;border-radius:9999px;border-width:2px;border-style:solid;--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
-.component-slider.su-slider-dark .component-slider-btn:hover{--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.component-slider.su-slider-dark .component-slider-btn:focus{--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .component-slider .component-slider-btn:hover){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
+:is(.su-dark .component-slider .component-slider-btn:focus-visible){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
+:is(.su-dark .component-slider .component-slider-btn:hover){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .component-slider .component-slider-btn:focus){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+.component-slider.su-slider-dark .component-slider-btn{position:relative;top:auto;bottom:0;height:37px;min-width:37px;max-width:37px;border-radius:9999px;border-width:2px;border-style:solid;--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity));transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
+.component-slider.su-slider-dark .component-slider-btn:hover{--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
+.component-slider.su-slider-dark .component-slider-btn:focus-visible{--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
+.component-slider.su-slider-dark .component-slider-btn:hover{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+.component-slider.su-slider-dark .component-slider-btn:focus{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 /*
 *   Global modal
 */
@@ -1878,6 +1908,8 @@ Subscribe to Stanford Report Marketo form styles
  */
 .su-page-campaign,
 .su-page-campaign body{--tw-bg-opacity:1;background-color:rgb(249 249 249 / var(--tw-bg-opacity))}
+.su-page-campaign.su-dark,
+.su-page-campaign.su-dark body{--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
 .scrollable-list__item::after{display:inline-block;vertical-align:middle}
 [data-component="story-lead"] .su-story-first-letter > *:first-child::first-letter{float:left;margin-top:0.2rem;margin-right:0.9rem;padding:0;font-family:"Source Serif 4", "Source Serif Pro", Georgia, Times, "Times New Roman", serif;font-size:7.2rem;font-weight:700;line-height:35px}
 @media (min-width: 768px){
@@ -2066,6 +2098,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 }
 .su-bg-gradient-light-red-h-reverse{background-image:linear-gradient(to left, var(--tw-gradient-stops));--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
 :is(.su-dark .su-bg-gradient-light-red-h-reverse){background-image:linear-gradient(to top left, var(--tw-gradient-stops));--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:rgb(39 153 137 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #279989 var(--tw-gradient-via-position), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+.su-aspect-h-16{--tw-aspect-h:16}
 .su-aspect-h-2{--tw-aspect-h:2}
 .su-aspect-w-1{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:1}
 .su-aspect-w-1 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
@@ -2073,6 +2106,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-aspect-w-2 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
 .su-aspect-w-3{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:3}
 .su-aspect-w-3 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
+.su-aspect-w-9{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:9}
+.su-aspect-w-9 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
 .su-button{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;cursor:pointer;display:inline-block;border:none;font-weight:400;line-height:1;text-align:center;text-decoration:none;width:auto;transition:background-color 0.25s ease-in-out, color 0.25s ease-in-out;padding:1rem 2rem;background-color:#B1040E;color:#fff;}
 .su-button:active, .su-button:hover, .su-button:focus{text-decoration:underline}
 .su-button:hover, .su-button:focus{background-color:#2E2D29;color:#fff}
@@ -2405,11 +2440,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su--bottom-1{bottom:-0.1rem}
 .su--left-80{left:-8rem}
 .su-bottom-0{bottom:0}
+.su-bottom-100{bottom:10rem}
+.su-bottom-120{bottom:12rem}
 .su-bottom-13{bottom:1.3rem}
 .su-bottom-20{bottom:2rem}
 .su-bottom-27{bottom:2.7rem}
+.su-bottom-34{bottom:3.4rem}
 .su-bottom-38{bottom:3.8rem}
 .su-bottom-4{bottom:0.4rem}
+.su-bottom-80{bottom:8rem}
 .su-bottom-\[-100px\]{bottom:-100px}
 .su-left-0{left:0}
 .su-left-1{left:0.1rem}
@@ -2418,6 +2457,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-left-20{left:2rem}
 .su-left-27{left:2.7rem}
 .su-left-3{left:0.3rem}
+.su-left-32{left:3.2rem}
 .su-left-38{left:3.8rem}
 .su-left-8{left:0.8rem}
 .su-left-9{left:0.9rem}
@@ -2505,7 +2545,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su--mt-2{margin-top:-0.2rem}
 .su--mt-50{margin-top:-5rem}
 .su-mb-0{margin-bottom:0}
+.su-mb-01em{margin-bottom:0.1em}
 .su-mb-02em{margin-bottom:0.2em}
+.su-mb-03em{margin-bottom:0.3em}
 .su-mb-10{margin-bottom:1rem}
 .su-mb-11{margin-bottom:1.1rem}
 .su-mb-12{margin-bottom:1.2rem}
@@ -2530,6 +2572,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mb-58{margin-bottom:5.8rem}
 .su-mb-6{margin-bottom:0.6rem}
 .su-mb-60{margin-bottom:6rem}
+.su-mb-61{margin-bottom:6.1rem}
 .su-mb-8{margin-bottom:0.8rem}
 .su-mb-9{margin-bottom:0.9rem}
 .su-mb-\[-\.5em\]{margin-bottom:-.5em}
@@ -2576,6 +2619,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mt-19{margin-top:1.9rem}
 .su-mt-2{margin-top:0.2rem}
 .su-mt-20{margin-top:2rem}
+.su-mt-200{margin-top:20rem}
 .su-mt-26{margin-top:2.6rem}
 .su-mt-27{margin-top:2.7rem}
 .su-mt-29{margin-top:2.9rem}
@@ -2613,6 +2657,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-aspect-\[1\/1\]{aspect-ratio:1/1}
 .su-aspect-\[16\/9\]{aspect-ratio:16/9}
 .su-aspect-\[3\/2\]{aspect-ratio:3/2}
+.su-aspect-\[9\/16\]{aspect-ratio:9/16}
 .su-size-100{width:10rem;height:10rem}
 .su-size-13{width:1.3rem;height:1.3rem}
 .su-size-14{width:1.4rem;height:1.4rem}
@@ -2776,6 +2821,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-flex-grow{flex-grow:1}
 .su-grow{flex-grow:1}
 .su-basis-1{flex-basis:0.1rem}
+.su-basis-4{flex-basis:0.4rem}
 .su-basis-auto{flex-basis:auto}
 .-su-translate-x-1{--tw-translate-x:-0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .-su-translate-x-1\/2{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -2950,6 +2996,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bg-black-30{--tw-bg-opacity:1;background-color:rgb(192 192 191 / var(--tw-bg-opacity))}
 .su-bg-black-40{--tw-bg-opacity:1;background-color:rgb(171 171 169 / var(--tw-bg-opacity))}
 .su-bg-black-true{--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
+.su-bg-black-true\/75{background-color:rgb(0 0 0 / 0.75)}
 .su-bg-black\/\[0\.33\]{background-color:rgb(46 45 41 / 0.33)}
 .su-bg-digital-green-dark{--tw-bg-opacity:1;background-color:rgb(0 111 84 / var(--tw-bg-opacity))}
 .su-bg-digital-red{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
@@ -2963,14 +3010,19 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bg-gradient-to-l{background-image:linear-gradient(to left, var(--tw-gradient-stops))}
 .su-bg-gradient-to-r{background-image:linear-gradient(to right, var(--tw-gradient-stops))}
 .su-bg-gradient-to-t{background-image:linear-gradient(to top, var(--tw-gradient-stops))}
+.su-from-black{--tw-gradient-from:#2E2D29 var(--tw-gradient-from-position);--tw-gradient-to:rgb(46 45 41 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-black-true{--tw-gradient-from:#000000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-black-true\/75{--tw-gradient-from:rgb(0 0 0 / 0.75) var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
+.su-from-black-true\/80{--tw-gradient-from:rgb(0 0 0 / 0.8) var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-digital-red{--tw-gradient-from:#B1040E var(--tw-gradient-from-position);--tw-gradient-to:rgb(177 4 14 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-digital-red-dark{--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-digital-red-light{--tw-gradient-from:#E50808 var(--tw-gradient-from-position);--tw-gradient-to:rgb(229 8 8 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-white{--tw-gradient-from:#fff var(--tw-gradient-from-position);--tw-gradient-to:rgb(255 255 255 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-via-\[rgb\(255_255_255\/\.5\)_8\%\]{--tw-gradient-to:rgb(255 255 255 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(255 255 255/.5) 8% var(--tw-gradient-via-position), var(--tw-gradient-to)}
+.su-via-black-true{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #000000 var(--tw-gradient-via-position), var(--tw-gradient-to)}
+.su-via-black-true\/60{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(0 0 0 / 0.6) var(--tw-gradient-via-position), var(--tw-gradient-to)}
 .su-via-digital-red-light{--tw-gradient-to:rgb(229 8 8 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #E50808 var(--tw-gradient-via-position), var(--tw-gradient-to)}
+.su-via-30\%{--tw-gradient-via-position:30%}
 .su-to-black-true{--tw-gradient-to:#000000 var(--tw-gradient-to-position)}
 .su-to-black-true\/60{--tw-gradient-to:rgb(0 0 0 / 0.6) var(--tw-gradient-to-position)}
 .su-to-cardinal-red-dark{--tw-gradient-to:#820000 var(--tw-gradient-to-position)}
@@ -2979,6 +3031,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-to-digital-red-light{--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
 .su-to-olive{--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
 .su-to-plum{--tw-gradient-to:#620059 var(--tw-gradient-to-position)}
+.su-to-transparent{--tw-gradient-to:transparent var(--tw-gradient-to-position)}
 .su-to-50\%{--tw-gradient-to-position:50%}
 .su-bg-cover{background-size:cover}
 .su-bg-center{background-position:center}
@@ -3015,6 +3068,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-px-22{padding-left:2.2rem;padding-right:2.2rem}
 .su-px-29{padding-left:2.9rem;padding-right:2.9rem}
 .su-px-30{padding-left:3rem;padding-right:3rem}
+.su-px-32{padding-left:3.2rem;padding-right:3.2rem}
 .su-px-35{padding-left:3.5rem;padding-right:3.5rem}
 .su-px-36{padding-left:3.6rem;padding-right:3.6rem}
 .su-px-38{padding-left:3.8rem;padding-right:3.8rem}
@@ -3146,6 +3200,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-\[2\.0rem\]{font-size:2.0rem}
 .su-text-\[2\.4rem\]{font-size:2.4rem}
 .su-text-\[3\.5rem\]{font-size:3.5rem}
+.su-text-\[3\.6rem\]{font-size:3.6rem}
 .su-text-\[33px\]{font-size:33px}
 .su-text-\[35px\]{font-size:35px}
 .su-text-\[39px\]{font-size:39px}
@@ -3924,6 +3979,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\*\:su-h-\[40px\] > *{height:40px}
 .\*\:su-w-\[40px\] > *{width:40px}
 .\*\:su-w-full > *{width:100%}
+.\*\:su-max-w-\[45rem\] > *{max-width:45rem}
+.\*\:su-basis-4\/5 > *{flex-basis:80%}
 .\*\:su-font-sans > *{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif}
 .\*\:su-text-16 > *{font-size:1.6rem}
 .\*\:su-text-18 > *{font-size:1.8rem}
@@ -4261,6 +4318,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 :is(.su-dark .su-group:focus-within .dark\:group-hocus-within\:su-text-digital-red-light){--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 :is(.su-dark .su-group:hover .dark\:group-hocus-within\:su-text-digital-red-light){--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 @media (min-width: 576px){
+.sm\:su-bottom-120{bottom:12rem}
+.sm\:su-bottom-61{bottom:6.1rem}
+.sm\:su-left-48{left:4.8rem}
 .sm\:su-left-\[10\%\]{left:10%}
 .sm\:su-right-\[10\%\]{right:10%}
 .sm\:su-col-span-10{grid-column:span 10 / span 10}
@@ -4289,6 +4349,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .sm\:su-text-23{font-size:2.3rem}
 .sm\:su-text-24{font-size:2.4rem}
 .sm\:su-text-\[22\.5px\]{font-size:22.5px}
+.sm\:su-text-\[4\.8rem\]{font-size:4.8rem}
 .sm\:su-text-\[6\.1rem\]{font-size:6.1rem}
 .sm\:su-leading-\[27px\]{line-height:27px}
 .sm\:su-leading-\[28\.75px\]{line-height:28.75px}}
@@ -4592,8 +4653,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 @media (min-width: 992px){
 .lg\:su-relative{position:relative}
 .lg\:su-bottom-0{bottom:0}
+.lg\:su-bottom-34{bottom:3.4rem}
 .lg\:su-bottom-38{bottom:3.8rem}
+.lg\:su-bottom-80{bottom:8rem}
 .lg\:su-bottom-\[15\.5rem\]{bottom:15.5rem}
+.lg\:su-left-32{left:3.2rem}
 .lg\:su-left-38{left:3.8rem}
 .lg\:su-right-0{right:0}
 .lg\:su-top-0{top:0}
@@ -4795,6 +4859,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-text-\[128px\]{font-size:128px}
 .lg\:su-text-\[2\.1rem\]{font-size:2.1rem}
 .lg\:su-text-\[2\.8rem\]{font-size:2.8rem}
+.lg\:su-text-\[3\.6rem\]{font-size:3.6rem}
 .lg\:su-text-\[32px\]{font-size:32px}
 .lg\:su-text-\[33px\]{font-size:33px}
 .lg\:su-text-\[4\.3rem\]{font-size:4.3rem}
@@ -4823,6 +4888,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\*\:lg\:su-size-100 > *{width:10rem;height:10rem}
 .\*\:lg\:su-h-\[100px\] > *{height:100px}
 .\*\:lg\:su-w-\[100px\] > *{width:100px}
+.\*\:lg\:su-basis-1\/3 > *{flex-basis:33.333333%}
 .\*\:lg\:su-text-19 > *{font-size:1.9rem}
 .lg\:\*\:su-text-21 > *{font-size:2.1rem}
 .lg\:\*\:su-text-26 > *{font-size:2.6rem}
@@ -4875,6 +4941,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .xl\:su-translate-y-\[-220px\]{--tw-translate-y:-220px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .xl\:su-grid-cols-2{grid-template-columns:repeat(2, minmax(0, 1fr))}
 .xl\:su-flex-row-reverse{flex-direction:row-reverse}
+.xl\:su-gap-40{gap:4rem}
 .xl\:su-gap-60{gap:6rem}
 .xl\:su-py-100{padding-top:10rem;padding-bottom:10rem}
 .xl\:su-pl-170{padding-left:17rem}
@@ -4883,8 +4950,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .xl\:su-text-\[3\.3rem\]{font-size:3.3rem}
 .xl\:su-text-\[6\.4rem\]{font-size:6.4rem}
 .xl\:su-text-\[6rem\]{font-size:6rem}
+.xl\:su-leading-snug{line-height:1.3}
 .xl\:\*\:su-leading-snug > *{line-height:1.3}}
 @media (min-width: 1500px){
+.\32xl\:su-bottom-120{bottom:12rem}
+.\32xl\:su-bottom-61{bottom:6.1rem}
+.\32xl\:su-left-48{left:4.8rem}
 .\32xl\:su--mt-58{margin-top:-5.8rem}
 .\32xl\:su-ml-80{margin-left:8rem}
 .\32xl\:su-mt-171{margin-top:17.1rem}
@@ -4893,13 +4964,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\32xl\:su-basis-\[70\%\]{flex-basis:70%}
 .\32xl\:su-flex-row{flex-direction:row}
 .\32xl\:su-gap-72{gap:7.2rem}
+.\32xl\:su-px-48{padding-left:4.8rem;padding-right:4.8rem}
 .\32xl\:su-px-\[17rem\]{padding-left:17rem;padding-right:17rem}
 .\32xl\:su-px-\[6\.6rem\]{padding-left:6.6rem;padding-right:6.6rem}
 .\32xl\:su-py-140{padding-top:14rem;padding-bottom:14rem}
 .\32xl\:su-pl-200{padding-left:20rem}
 .\32xl\:su-pl-76{padding-left:7.6rem}
 .\32xl\:su-text-\[2\.9rem\]{font-size:2.9rem}
-.\32xl\:su-text-\[3\.3rem\]{font-size:3.3rem}}
+.\32xl\:su-text-\[3\.3rem\]{font-size:3.3rem}
+.\32xl\:su-text-\[4\.8rem\]{font-size:4.8rem}}
 .\[\&\>\*\:last-child\]\:su-mb-0>*:last-child{margin-bottom:0}
 .\[\&\>\*\:last-child\]\:after\:su-content-\[\'\\u201D\'\]>*:last-child::after{--tw-content:'\u201D';content:var(--tw-content)}
 .\[\&\>\*\:last-child\]\:after\:su-content-\[\'\201D\'\]>*:last-child::after{--tw-content:'”';content:var(--tw-content)}
@@ -4926,6 +4999,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\[\&\>svg\]\:su-w-41>svg{width:4.1rem}
 .\[\&\>svg\]\:su-translate-y-1>svg{--tw-translate-y:0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>svg\]\:su-text-\[4rem\]>svg{font-size:4rem}
+.\[\&\>svg\]\:su-text-\[6rem\]>svg{font-size:6rem}
 @media (min-width: 768px){
 .md\:\[\&\>svg\]\:su--mt-2>svg{margin-top:-0.2rem}
 .md\:\[\&\>svg\]\:su-h-\[102px\]>svg{height:102px}

--- a/global/css/_global.css
+++ b/global/css/_global.css
@@ -191,7 +191,7 @@ svg {
 
 .component-slider-peek .swiper-slide-prev > *,
 .component-slider-peek .swiper-slide-next > * {
-  @apply su-opacity-[.27] md:su-opacity-100 su-pointer-events-none md:su-pointer-events-auto;
+  @apply su-opacity-25 md:su-opacity-100 su-pointer-events-none md:su-pointer-events-auto;
 }
 
 .component-slider-single.component-slider-peek {
@@ -204,7 +204,17 @@ svg {
 
 .component-slider-single.component-slider-peek .swiper-slide-prev > *,
 .component-slider-single.component-slider-peek .swiper-slide-next > * {
-  @apply su-opacity-[.27] md:su-opacity-100 su-pointer-events-none md:su-pointer-events-auto;
+  @apply su-opacity-25 md:su-opacity-100 su-pointer-events-none md:su-pointer-events-auto;
+}
+
+.component-slider-single.component-slider-peek.component-slider-vertical-videos .swiper-slide-prev > *,
+.component-slider-single.component-slider-peek.component-slider-vertical-videos .swiper-slide-next > * {
+  @apply su-opacity-25 su-pointer-events-none;
+}
+
+.su-slider-dark .component-slider-single.component-slider-peek.component-slider-vertical-videos .swiper-slide-prev > *,
+.su-slider-dark .component-slider-single.component-slider-peek.component-slider-vertical-videos .swiper-slide-next > * {
+  @apply su-opacity-40 su-pointer-events-none;
 }
 
 .component-slider .component-slider-pagination {
@@ -212,11 +222,23 @@ svg {
 }
 
 .component-slider .swiper-pagination-bullet {
-  @apply su-mx-0 su-transition su-opacity-100 su-w-20 su-h-20 su-bg-transparent su-border-2 su-border-solid su-border-black-30 dark:su-border-black-60;
+  @apply su-mx-0 su-transition su-opacity-100 su-w-20 su-h-20 su-bg-transparent su-border-2 su-border-solid su-border-black-40 dark:su-border-black-60;
 }
 
 .component-slider.su-slider-dark .swiper-pagination-bullet {
   @apply su-mx-0 su-transition su-opacity-100 su-w-20 su-h-20 su-bg-transparent su-border-2 su-border-solid su-border-black-60;
+}
+
+.component-slider .component-slider-vertical-videos + .component-slider-controls {
+  @apply su-cc;
+}
+
+.component-slider.su-slider-dark .component-slider-vertical-videos + .component-slider-controls .swiper-pagination-bullet {
+  @apply su-border-2 su-border-white hover:su-border-dark-mode-red focus-visible:su-border-dark-mode-red active:su-border-dark-mode-red;
+}
+
+.component-slider.su-slider-dark .component-slider-vertical-videos + .component-slider-controls .swiper-pagination-bullet.swiper-pagination-bullet-active {
+  @apply su-border-dark-mode-red su-bg-dark-mode-red;
 }
 
 .component-slider .swiper-pagination-lock {
@@ -234,14 +256,12 @@ svg {
   margin: 0 !important;
 }
 
-.component-slider.su-slider-dark .swiper-pagination-bullet:hover,
-.component-slider.su-slider-dark .swiper-pagination-bullet:active {
-  @apply su-border-dark-mode-red;
+.component-slider.su-slider-dark .swiper-pagination-bullet {
+  @apply hover:su-border-dark-mode-red focus-visible:su-border-dark-mode-red active:su-border-dark-mode-red;
 }
 
-.component-slider .swiper-pagination-bullet:hover,
-.component-slider .swiper-pagination-bullet:active {
-  @apply su-border-digital-red dark:su-border-dark-mode-red;
+.component-slider .swiper-pagination-bullet {
+  @apply hover:su-border-digital-red focus-visible:su-border-digital-red active:su-border-digital-red dark:hover:su-border-dark-mode-red dark:focus-visible:su-border-dark-mode-red dark:active:su-border-dark-mode-red;
 }
 
 .component-slider .swiper-pagination-bullet.swiper-pagination-bullet-active {
@@ -271,11 +291,11 @@ svg {
 }
 
 .component-slider .component-slider-btn {
-  @apply su-transition hocus:su-bg-digital-red hocus:su-text-white dark:hocus:su-bg-dark-mode-red dark:hocus:su-text-white su-relative su-min-w-37 su-max-w-37 su-h-37 su-top-auto su-bottom-0 su-border-2 su-border-digital-red dark:su-border-dark-mode-red su-rounded-full;
+  @apply su-transition hover:su-bg-digital-red focus-visible:su-bg-digital-red hover:su-text-white focus-visible:su-text-white dark:hover:su-bg-dark-mode-red dark:focus-visible:su-bg-dark-mode-red dark:hocus:su-text-white su-relative su-min-w-37 su-max-w-37 su-h-37 su-top-auto su-bottom-0 su-border-2 su-border-digital-red dark:su-border-dark-mode-red su-rounded-full;
 }
 
 .component-slider.su-slider-dark .component-slider-btn {
-  @apply su-transition hocus:su-text-white hocus:su-bg-dark-mode-red hocus:su-text-white su-relative su-min-w-[37px] su-max-w-[37px] su-h-[37px] su-top-auto su-bottom-0 su-border-solid su-border-2 su-border-dark-mode-red su-rounded-full;
+  @apply su-transition su-text-white hover:su-bg-dark-mode-red focus-visible:su-bg-dark-mode-red hocus:su-text-white su-relative su-min-w-[37px] su-max-w-[37px] su-h-[37px] su-top-auto su-bottom-0 su-border-solid su-border-2 su-border-dark-mode-red su-rounded-full;
 }
 
 /*
@@ -1247,4 +1267,9 @@ Subscribe to Stanford Report Marketo form styles
 .su-page-campaign,
 .su-page-campaign body {
   @apply su-bg-campaign-fog;
+}
+
+.su-page-campaign.su-dark,
+.su-page-campaign.su-dark body {
+  @apply su-bg-black-true;
 }

--- a/global/js/_global.js
+++ b/global/js/_global.js
@@ -1,3 +1,4 @@
+import '../../components/vertical-videos-panel/client.jsx';
 import '../../components/topic-subtopic-listing/client.jsx';
 import '../../components/text-callout/client.jsx';
 import '../../components/subtopics-subnav/client.jsx';

--- a/packages/__globalPreview/left-sidebar.html
+++ b/packages/__globalPreview/left-sidebar.html
@@ -75,7 +75,9 @@
             hendrerit gravida.
           </p>
         </div>
-        <aside class="su-page-sidebar--left">[component://output]</aside>
+        <aside class="su-page-sidebar--left">
+          <div data-component="sidebar-navigation" data-hydration-component="sidebar-navigation" data-hydration-props='{"id":157300, "root":"157300"}'></div>
+        </aside>
       </div>
     </main>
     [component://static-footer]

--- a/packages/card/CardThumbnail.jsx
+++ b/packages/card/CardThumbnail.jsx
@@ -12,6 +12,8 @@ const videoPlayClasses = {
   large: "su-left-13 su-bottom-13 [&>svg]:su-text-[4rem]",
   featured:
     "su-left-13 su-bottom-13 md:su-left-27 md:su-bottom-27 [&>svg]:su-text-[4rem] [&>svg]:md:su-text-[6rem]",
+  "vertical-video":
+    "su-left-32 su-bottom-34 sm:su-left-48 sm:su-bottom-61 lg:su-left-32 lg:su-bottom-34 2xl:su-left-48 2xl:su-bottom-61 [&>svg]:su-text-[6rem]",
 };
 
 export default function CardThumbnail({
@@ -46,10 +48,18 @@ export default function CardThumbnail({
           imageAlt={`Open video ${alt || ""} in a modal`}
           aspectRatio={aspectRatio}
         >
+          {/* Add a dark overlay over the image when used in Vertical Video Cards */}
+          {size === "vertical-video" && (
+            <div
+              aria-hidden="true"
+              className="su-absolute su-inset-0 su-bg-gradient-to-t su-from-black-true/80 su-via-30% su-via-black-true/60 su-pointer-events-none su-z-20"
+            />
+          )}
           {videoUrl && (
             <span
               className={cnb(
                 "su-absolute su-leading-none",
+                size === "vertical-video" && "su-z-30",
                 // eslint-disable-next-line security/detect-object-injection
                 videoPlayClasses[size],
                 videoIconClasses
@@ -71,7 +81,11 @@ export default function CardThumbnail({
           title="Modal"
           onClose={handleCloseModal}
         >
-          <EmbedVideo videoId={videoUrl} title={`Watch ${title}`} />
+          <EmbedVideo
+            isVertical={size === "vertical-video"}
+            videoId={videoUrl}
+            title={`Watch ${title}`}
+          />
         </Modal>
       )}
     </>

--- a/packages/card/VerticalVideoCard/VerticalVideoCard.jsx
+++ b/packages/card/VerticalVideoCard/VerticalVideoCard.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import CardThumbnail from "../CardThumbnail";
+import * as styles from "./VerticalVideoCard.styles";
+
+/**
+ * Vertical Video Card component
+ * This card is used in the Vertical Videos Panel component
+ *
+ * @param {string} heading
+ * The card heading
+ *
+ * @param {string} subheading
+ * The card subheading
+ *
+ * @param {string} youtubeId
+ * The video ID of the YouTube short
+ *
+ * @param {string} videoImageUrl
+ * The URL of the video preview image
+ *
+ * @param {string} videoImageAlt
+ * The alt text of the video preview image
+ *
+ * @return {JSX.element}
+ */
+
+export function VerticalVideoCard({
+  heading,
+  subheading,
+  youtubeId,
+  videoImageUrl,
+  videoImageAlt,
+}) {
+  return (
+    <article className={styles.root}>
+      <div className={styles.contentWrapper}>
+        <h3 className={styles.heading}>{heading}</h3>
+        <p className={styles.subheading}>{subheading}</p>
+      </div>
+      <div className={styles.imageWrapper}>
+        <CardThumbnail
+          imageUrl={videoImageUrl}
+          alt={videoImageAlt}
+          title={heading}
+          aspectRatio="vertical-video"
+          videoUrl={youtubeId}
+          size="vertical-video"
+          videoIconClasses={styles.videoIcon}
+        />
+      </div>
+    </article>
+  );
+}

--- a/packages/card/VerticalVideoCard/VerticalVideoCard.styles.js
+++ b/packages/card/VerticalVideoCard/VerticalVideoCard.styles.js
@@ -1,0 +1,11 @@
+export const root = "su-relative su-flex su-flex-col su-text-white su-bg-black";
+
+export const imageWrapper = "su-relative su-w-full";
+export const videoIcon = "group-hocus:su-scale-110 su-transition-transform";
+
+export const contentWrapper =
+  "su-absolute su-inset su-z-40 su-px-32 2xl:su-px-48 su-bottom-100 sm:su-bottom-120 lg:su-bottom-80 2xl:su-bottom-120 su-pointer-events-none su-text-center su-flex su-flex-col su-items-center su-w-full su-rs-mb-3";
+export const heading =
+  "su-text-[3.6rem] sm:su-text-[4.8rem] lg:su-text-[3.6rem] 2xl:su-text-[4.8rem] su-leading-display su-mb-6";
+export const subheading =
+  "su-text-21 su-mb-0 su-leading-display xl:su-leading-snug";

--- a/packages/carousels/Carousel.jsx
+++ b/packages/carousels/Carousel.jsx
@@ -45,6 +45,32 @@ export function Carousel({
     variantClassName: "component-slider-cards component-slider-peek",
     loop: true,
   });
+  variants.set("vertical-videos", {
+    breakpoints: {
+      0: {
+        slidesPerView: 1.4,
+        spaceBetween: 20,
+        centeredSlides: true,
+        initialSlide: 0,
+      },
+      576: {
+        slidesPerView: 1.6,
+        spaceBetween: 20,
+        centeredSlides: true,
+        initialSlide: 0,
+      },
+      768: {
+        slidesPerView: 1.9,
+        spaceBetween: 50,
+        centeredSlides: true,
+        initialSlide: 0,
+      },
+    },
+    slidesPerView: 1,
+    variantClassName:
+      "component-slider-single component-slider-vertical-videos component-slider-peek",
+    loop: true,
+  });
   variants.set("media", {
     breakpoints: {
       0: {
@@ -198,8 +224,8 @@ export function Carousel({
               const slide = swiper.$wrapperEl?.[0].querySelector(
                 ".swiper-slide-active"
               );
-              const slideTarget = slide.querySelector("h2 a, h3 a")
-                ? slide.querySelector("h2 a, h3 a")
+              const slideTarget = slide.querySelector("h2 a, h3 a, button")
+                ? slide.querySelector("h2 a, h3 a, button")
                 : (() => {
                     slide.setAttribute("tabindex", "-1");
                     return slide;

--- a/packages/media/EmbedVideo.jsx
+++ b/packages/media/EmbedVideo.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 
 export default function EmbedVideo(props) {
-  const { videoId, className, noAutoPlay, title } = props;
+  const { videoId, className, noAutoPlay, title, isVertical } = props;
 
   return (
     <iframe
-      width="560"
-      height="315"
+      width={isVertical ? 315 : 560}
+      height={isVertical ? 560 : 315}
       className={className}
       src={`https://www.youtube.com/embed/${videoId}?si=vYU81uVmaV7GSju2&amp;autoplay=${
         noAutoPlay ? 0 : 1

--- a/packages/media/MediaRatio.jsx
+++ b/packages/media/MediaRatio.jsx
@@ -13,6 +13,7 @@ export default function MediaRatio({
   aspectRatioMap.set("card-large", "su-aspect-[3/2]");
   aspectRatioMap.set("card-featured", "su-aspect-[16/9]");
   aspectRatioMap.set("square", "su-aspect-[1/1]");
+  aspectRatioMap.set("vertical-video", "su-aspect-[9/16]");
 
   return (
     <span


### PR DESCRIPTION
# READY FOR REVIEW

# Summary

- Update the dark mode hocus styles to match that of the light mode. We don’t need a color difference in font because the text is not on a black background.
  - I also updated the dark mode book / audio icon to match light mode - same reason
- Update so that the entire transparent card area is clickable.

# Review By

9/5/2024

# Criticality

1 - Minor

# Review Tasks

1. Visit https://news.stanford.edu/developreport/stories/jb-test-page
1. Confirm that the entire Media Feature component is a link
1. Confirm the link :hocus style is the same in dark mode as it is in light mode
    1. @iamrentman @broleomo Is it ok that the entire summary is underlined on `:hocus`? That looks weird to me.
1. Confirm the book icon  is the same in dark mode as it is in light mode

# Associated Issues and/or People

- [UCP-3444](https://stanfordits.atlassian.net/browse/UCP-3444)


[UCP-3444]: https://stanfordits.atlassian.net/browse/UCP-3444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ