### PR TITLE
UCP-3444: Media Feature: dark mode hocus; make whole card link

### DIFF
--- a/components/media-feature/Component.jsx
+++ b/components/media-feature/Component.jsx
@@ -2,10 +2,9 @@ import React from "react";
 
 // import specific templates for the component
 import { Container } from "../../packages/grids/Container";
+import { SidebarHeading } from "../../packages/headings/Heading";
 import {
   Podcast,
-  FeaturedAudio,
-  FeaturedReading,
   ExternalArrow,
   BookOpenCover,
 } from "../../packages/SVG-library/SVG";
@@ -40,49 +39,52 @@ export default function MediaFeature({
   return (
     <Container width="full" paddingX={false}>
       <section className="su-py-45 su-px-20 su-flex su-justify-center su-relative md:su-py-72 md:su-px-50">
-        <a href={linkUrl} className="su-media-feature-title-link su-group">
-          <div className="su-max-w-[1086px] su-flex su-flex-col su-items-center su-z-[2] su-relative su-p-38 before:su-content-[''] before:su-bg-foggy-light before:su-w-full before:su-h-full before:su-opacity-90 before:su-absolute before:su-z-[-1] before:su-top-0 before:su-left-0 md:su-flex-row md:su-gap-20 md:su-items-start lg:su-p-48 lg:su-gap-48">
-            {/* <div className="su-h-[224px] su-w-[224px] su-relative su-shrink-0 md:su-w-[182px] md:su-h-[182px] lg:su-w-[292px] lg:su-h-[292px]"> */}
-            <div
-              className={`${
-                mediaType === "Podcast" &&
-                "su-w-[224px] md:su-w-[182px] lg:su-w-[292px]"
-              } su-h-[224px] md:su-h-[182px] lg:su-h-[292px] su-relative su-shrink-0 ${
-                mediaType === "Book" && "media-feature__thumb"
-              }`}
-            >
-              <img
-                // src="https://picsum.photos/600/250"
-                src={imageData.url}
-                alt={imageData.attributes.alt}
-                className={thumbMap.get(mediaType)}
-                // className="su-media-card-thumb su-size-full su-object-scale-down su-object-center"
-                // className="su-absolute su-object-cover su-rounded-[8px] su-z-[2] su-flex-1 su-size-full su-shadow-[0px_4px_7px_0px_rgba(0,0,0,0.15)]"
-              />
+        <div className="su-max-w-[1086px] su-flex su-flex-col su-items-center su-z-[2] su-relative su-p-38 before:su-content-[''] before:su-bg-foggy-light before:su-w-full before:su-h-full before:su-opacity-90 before:su-absolute before:su-z-[-1] before:su-top-0 before:su-left-0 md:su-flex-row md:su-gap-20 md:su-items-start lg:su-p-48 lg:su-gap-48">
+          {/* <div className="su-h-[224px] su-w-[224px] su-relative su-shrink-0 md:su-w-[182px] md:su-h-[182px] lg:su-w-[292px] lg:su-h-[292px]"> */}
+          <div
+            className={`${
+              mediaType === "Podcast" &&
+              "su-w-[224px] md:su-w-[182px] lg:su-w-[292px]"
+            } su-h-[224px] md:su-h-[182px] lg:su-h-[292px] su-relative su-shrink-0 ${
+              mediaType === "Book" && "media-feature__thumb"
+            }`}
+          >
+            <img
+              // src="https://picsum.photos/600/250"
+              src={imageData.url}
+              alt={imageData.attributes.alt}
+              className={thumbMap.get(mediaType)}
+              // className="su-media-card-thumb su-size-full su-object-scale-down su-object-center"
+              // className="su-absolute su-object-cover su-rounded-[8px] su-z-[2] su-flex-1 su-size-full su-shadow-[0px_4px_7px_0px_rgba(0,0,0,0.15)]"
+            />
+          </div>
+
+          <div>
+            <div className="su-py-20 su-w-full md:su-pb-27 md:su-pt-0 *:dark:su-text-black">
+              <FeaturedHeading type={mediaType} />
             </div>
 
-            <div>
-              <div className="su-py-20 su-w-full md:su-pb-27 md:su-pt-0 *:dark:su-text-black">
-                <FeaturedHeading type={mediaType} />
-              </div>
-
+            <a
+              href={linkUrl}
+              className="su-media-feature-title-link su-stretched-link su-group"
+            >
               <h3 className="su-text-[35px] su-font-bold su-leading-tight su-m-0 su-pb-8 md:su-pb-19 md:su-text-[40px] lg:su-text-[43px]">
                 {title}
                 <span className="su-hidden lg:su-inline-block su-relative su-top-12 [&>*]:su-stroke-digital-red dark:[&>*]:su-stroke-dark-mode-red su-transition group-hocus:su--translate-y-01em group-hocus:su-translate-x-01em [&>svg]:su-translate-y-1">
                   <ExternalArrow size="large" />
                 </span>
               </h3>
+            </a>
 
-              <div className="su-w-full su-flex su-gap-[0.6rem] su-text-18 su-text-black-70 su-font-semibold su-items-center su-pb-15 su-leading-snug md:su-pb-19 md:su-text-16">
-                <MediaType type={mediaType} />
-              </div>
-
-              <p className="su-text-18 su-w-full su-m-0 su-leading-[125%] su-text-black su-font-normal md:su-text-19 lg:su-text-21">
-                {teaserText}
-              </p>
+            <div className="su-w-full su-flex su-gap-[0.6rem] su-text-18 su-text-black-70 su-font-semibold su-items-center su-pb-15 su-leading-snug md:su-pb-19 md:su-text-16">
+              <MediaType type={mediaType} />
             </div>
+
+            <p className="su-text-18 su-w-full su-m-0 su-leading-[125%] su-text-black su-font-normal md:su-text-19 lg:su-text-21">
+              {teaserText}
+            </p>
           </div>
-        </a>
+        </div>
 
         <img
           // src="https://picsum.photos/1300/"
@@ -112,8 +114,8 @@ function MediaType({ type }) {
 function FeaturedHeading({ type }) {
   switch (type) {
     case "Podcast":
-      return <FeaturedAudio variant="light" />;
+      return <SidebarHeading icon="Featured audio" title="Featured audio" />;
     default:
-      return <FeaturedReading variant="light" />;
+      return <SidebarHeading icon="Featured reading" title="Featured book" />;
   }
 }

--- a/components/media-feature/Component.jsx
+++ b/components/media-feature/Component.jsx
@@ -2,9 +2,10 @@ import React from "react";
 
 // import specific templates for the component
 import { Container } from "../../packages/grids/Container";
-import { SidebarHeading } from "../../packages/headings/Heading";
 import {
   Podcast,
+  FeaturedAudio,
+  FeaturedReading,
   ExternalArrow,
   BookOpenCover,
 } from "../../packages/SVG-library/SVG";
@@ -39,49 +40,49 @@ export default function MediaFeature({
   return (
     <Container width="full" paddingX={false}>
       <section className="su-py-45 su-px-20 su-flex su-justify-center su-relative md:su-py-72 md:su-px-50">
-        <div className="su-max-w-[1086px] su-flex su-flex-col su-items-center su-z-[2] su-relative su-p-38 before:su-content-[''] before:su-bg-foggy-light before:su-w-full before:su-h-full before:su-opacity-90 before:su-absolute before:su-z-[-1] before:su-top-0 before:su-left-0 md:su-flex-row md:su-gap-20 md:su-items-start lg:su-p-48 lg:su-gap-48">
-          {/* <div className="su-h-[224px] su-w-[224px] su-relative su-shrink-0 md:su-w-[182px] md:su-h-[182px] lg:su-w-[292px] lg:su-h-[292px]"> */}
-          <div
-            className={`${
-              mediaType === "Podcast" &&
-              "su-w-[224px] md:su-w-[182px] lg:su-w-[292px]"
-            } su-h-[224px] md:su-h-[182px] lg:su-h-[292px] su-relative su-shrink-0 ${
-              mediaType === "Book" && "media-feature__thumb"
-            }`}
-          >
-            <img
-              // src="https://picsum.photos/600/250"
-              src={imageData.url}
-              alt={imageData.attributes.alt}
-              className={thumbMap.get(mediaType)}
-              // className="su-media-card-thumb su-size-full su-object-scale-down su-object-center"
-              // className="su-absolute su-object-cover su-rounded-[8px] su-z-[2] su-flex-1 su-size-full su-shadow-[0px_4px_7px_0px_rgba(0,0,0,0.15)]"
-            />
-          </div>
-
-          <div>
-            <div className="su-py-20 su-w-full md:su-pb-27 md:su-pt-0 *:dark:su-text-black">
-              <FeaturedHeading type={mediaType} />
+        <a href={linkUrl} className="su-media-feature-title-link su-group">
+          <div className="su-max-w-[1086px] su-flex su-flex-col su-items-center su-z-[2] su-relative su-p-38 before:su-content-[''] before:su-bg-foggy-light before:su-w-full before:su-h-full before:su-opacity-90 before:su-absolute before:su-z-[-1] before:su-top-0 before:su-left-0 md:su-flex-row md:su-gap-20 md:su-items-start lg:su-p-48 lg:su-gap-48">
+            {/* <div className="su-h-[224px] su-w-[224px] su-relative su-shrink-0 md:su-w-[182px] md:su-h-[182px] lg:su-w-[292px] lg:su-h-[292px]"> */}
+            <div
+              className={`${
+                mediaType === "Podcast" &&
+                "su-w-[224px] md:su-w-[182px] lg:su-w-[292px]"
+              } su-h-[224px] md:su-h-[182px] lg:su-h-[292px] su-relative su-shrink-0 ${
+                mediaType === "Book" && "media-feature__thumb"
+              }`}
+            >
+              <img
+                // src="https://picsum.photos/600/250"
+                src={imageData.url}
+                alt={imageData.attributes.alt}
+                className={thumbMap.get(mediaType)}
+                // className="su-media-card-thumb su-size-full su-object-scale-down su-object-center"
+                // className="su-absolute su-object-cover su-rounded-[8px] su-z-[2] su-flex-1 su-size-full su-shadow-[0px_4px_7px_0px_rgba(0,0,0,0.15)]"
+              />
             </div>
 
-            <a href={linkUrl} className="su-media-feature-title-link su-group">
+            <div>
+              <div className="su-py-20 su-w-full md:su-pb-27 md:su-pt-0 *:dark:su-text-black">
+                <FeaturedHeading type={mediaType} />
+              </div>
+
               <h3 className="su-text-[35px] su-font-bold su-leading-tight su-m-0 su-pb-8 md:su-pb-19 md:su-text-[40px] lg:su-text-[43px]">
                 {title}
                 <span className="su-hidden lg:su-inline-block su-relative su-top-12 [&>*]:su-stroke-digital-red dark:[&>*]:su-stroke-dark-mode-red su-transition group-hocus:su--translate-y-01em group-hocus:su-translate-x-01em [&>svg]:su-translate-y-1">
                   <ExternalArrow size="large" />
                 </span>
               </h3>
-            </a>
 
-            <div className="su-w-full su-flex su-gap-[0.6rem] su-text-18 su-text-black-70 su-font-semibold su-items-center su-pb-15 su-leading-snug md:su-pb-19 md:su-text-16">
-              <MediaType type={mediaType} />
+              <div className="su-w-full su-flex su-gap-[0.6rem] su-text-18 su-text-black-70 su-font-semibold su-items-center su-pb-15 su-leading-snug md:su-pb-19 md:su-text-16">
+                <MediaType type={mediaType} />
+              </div>
+
+              <p className="su-text-18 su-w-full su-m-0 su-leading-[125%] su-text-black su-font-normal md:su-text-19 lg:su-text-21">
+                {teaserText}
+              </p>
             </div>
-
-            <p className="su-text-18 su-w-full su-m-0 su-leading-[125%] su-text-black su-font-normal md:su-text-19 lg:su-text-21">
-              {teaserText}
-            </p>
           </div>
-        </div>
+        </a>
 
         <img
           // src="https://picsum.photos/1300/"
@@ -111,8 +112,8 @@ function MediaType({ type }) {
 function FeaturedHeading({ type }) {
   switch (type) {
     case "Podcast":
-      return <SidebarHeading icon="Featured audio" title="Featured audio" />;
+      return <FeaturedAudio variant="light" />;
     default:
-      return <SidebarHeading icon="Featured reading" title="Featured book" />;
+      return <FeaturedReading variant="light" />;
   }
 }

--- a/components/media-feature/Component.jsx
+++ b/components/media-feature/Component.jsx
@@ -39,7 +39,7 @@ export default function MediaFeature({
   return (
     <Container width="full" paddingX={false}>
       <section className="su-py-45 su-px-20 su-flex su-justify-center su-relative md:su-py-72 md:su-px-50">
-        <div className="su-max-w-[1086px] su-flex su-flex-col su-items-center su-z-[2] su-relative su-p-38 before:su-content-[''] before:su-bg-foggy-light before:su-w-full before:su-h-full before:su-opacity-90 before:su-absolute before:su-z-[-1] before:su-top-0 before:su-left-0 md:su-flex-row md:su-gap-20 md:su-items-start lg:su-p-48 lg:su-gap-48">
+        <div className="su-group su-max-w-[1086px] su-flex su-flex-col su-items-center su-z-[2] su-relative su-p-38 before:su-content-[''] before:su-bg-foggy-light before:su-w-full before:su-h-full before:su-opacity-90 before:su-absolute before:su-z-[-1] before:su-top-0 before:su-left-0 md:su-flex-row md:su-gap-20 md:su-items-start lg:su-p-48 lg:su-gap-48">
           <div
             className={`${
               mediaType === "Podcast" &&
@@ -63,7 +63,7 @@ export default function MediaFeature({
             <h3 className="su-text-[35px] su-font-bold su-leading-tight su-m-0 su-pb-8 md:su-pb-19 md:su-text-[40px] lg:su-text-[43px]">
               <a
                 href={linkUrl}
-                className="su-media-feature-title-link su-stretched-link su-group"
+                className="su-media-feature-title-link su-stretched-link"
               >
                 {title}
                 <span className="su-hidden lg:su-inline-block su-relative su-top-12 [&>*]:su-stroke-digital-red dark:[&>*]:su-stroke-dark-mode-red su-transition group-hocus:su--translate-y-01em group-hocus:su-translate-x-01em [&>svg]:su-translate-y-1">

--- a/components/media-feature/Component.jsx
+++ b/components/media-feature/Component.jsx
@@ -40,7 +40,6 @@ export default function MediaFeature({
     <Container width="full" paddingX={false}>
       <section className="su-py-45 su-px-20 su-flex su-justify-center su-relative md:su-py-72 md:su-px-50">
         <div className="su-max-w-[1086px] su-flex su-flex-col su-items-center su-z-[2] su-relative su-p-38 before:su-content-[''] before:su-bg-foggy-light before:su-w-full before:su-h-full before:su-opacity-90 before:su-absolute before:su-z-[-1] before:su-top-0 before:su-left-0 md:su-flex-row md:su-gap-20 md:su-items-start lg:su-p-48 lg:su-gap-48">
-          {/* <div className="su-h-[224px] su-w-[224px] su-relative su-shrink-0 md:su-w-[182px] md:su-h-[182px] lg:su-w-[292px] lg:su-h-[292px]"> */}
           <div
             className={`${
               mediaType === "Podcast" &&
@@ -50,12 +49,9 @@ export default function MediaFeature({
             }`}
           >
             <img
-              // src="https://picsum.photos/600/250"
               src={imageData.url}
               alt={imageData.attributes.alt}
               className={thumbMap.get(mediaType)}
-              // className="su-media-card-thumb su-size-full su-object-scale-down su-object-center"
-              // className="su-absolute su-object-cover su-rounded-[8px] su-z-[2] su-flex-1 su-size-full su-shadow-[0px_4px_7px_0px_rgba(0,0,0,0.15)]"
             />
           </div>
 
@@ -87,7 +83,6 @@ export default function MediaFeature({
         </div>
 
         <img
-          // src="https://picsum.photos/1300/"
           src={bgImageData.url}
           className="su-absolute su-size-full su-object-cover su-left-0 su-top-0 su-z-[1]"
           alt={bgImageData.attributes.alt}

--- a/components/media-feature/Component.jsx
+++ b/components/media-feature/Component.jsx
@@ -114,8 +114,20 @@ function MediaType({ type }) {
 function FeaturedHeading({ type }) {
   switch (type) {
     case "Podcast":
-      return <SidebarHeading icon="Featured audio" title="Featured audio" />;
+      return (
+        <SidebarHeading
+          icon="Featured audio"
+          title="Featured audio"
+          darkVariant="light"
+        />
+      );
     default:
-      return <SidebarHeading icon="Featured reading" title="Featured book" />;
+      return (
+        <SidebarHeading
+          icon="Featured reading"
+          title="Featured book"
+          darkVariant="light"
+        />
+      );
   }
 }

--- a/components/media-feature/Component.jsx
+++ b/components/media-feature/Component.jsx
@@ -64,17 +64,17 @@ export default function MediaFeature({
               <FeaturedHeading type={mediaType} />
             </div>
 
-            <a
-              href={linkUrl}
-              className="su-media-feature-title-link su-stretched-link su-group"
-            >
-              <h3 className="su-text-[35px] su-font-bold su-leading-tight su-m-0 su-pb-8 md:su-pb-19 md:su-text-[40px] lg:su-text-[43px]">
+            <h3 className="su-text-[35px] su-font-bold su-leading-tight su-m-0 su-pb-8 md:su-pb-19 md:su-text-[40px] lg:su-text-[43px]">
+              <a
+                href={linkUrl}
+                className="su-media-feature-title-link su-stretched-link su-group"
+              >
                 {title}
                 <span className="su-hidden lg:su-inline-block su-relative su-top-12 [&>*]:su-stroke-digital-red dark:[&>*]:su-stroke-dark-mode-red su-transition group-hocus:su--translate-y-01em group-hocus:su-translate-x-01em [&>svg]:su-translate-y-1">
                   <ExternalArrow size="large" />
                 </span>
-              </h3>
-            </a>
+              </a>
+            </h3>
 
             <div className="su-w-full su-flex su-gap-[0.6rem] su-text-18 su-text-black-70 su-font-semibold su-items-center su-pb-15 su-leading-snug md:su-pb-19 md:su-text-16">
               <MediaType type={mediaType} />

--- a/components/media-feature/Component.jsx
+++ b/components/media-feature/Component.jsx
@@ -114,20 +114,8 @@ function MediaType({ type }) {
 function FeaturedHeading({ type }) {
   switch (type) {
     case "Podcast":
-      return (
-        <SidebarHeading
-          icon="Featured audio"
-          title="Featured audio"
-          darkVariant="light"
-        />
-      );
+      return <SidebarHeading icon="Featured audio" title="Featured audio" />;
     default:
-      return (
-        <SidebarHeading
-          icon="Featured reading"
-          title="Featured book"
-          darkVariant="light"
-        />
-      );
+      return <SidebarHeading icon="Featured reading" title="Featured book" />;
   }
 }

--- a/components/media-feature/main.css
+++ b/components/media-feature/main.css
@@ -3,5 +3,5 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 }
 
 .su-media-feature-title-link {
-  @apply su-no-underline hocus:su-underline dark:su-text-black hocus:su-text-digital-red dark:hocus:su-text-dark-mode-red;
+  @apply su-no-underline hocus:su-underline dark:su-text-black hocus:su-text-digital-red dark:hocus:su-text-digital-red;
 }

--- a/components/media-feature/manifest.json
+++ b/components/media-feature/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "media-feature",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "namespace": "stanford-components",
   "description": "THe media feature component is used to feature a singluar podcast or book.",
   "displayName": "Media Feature",

--- a/components/media-feature/manifest.json
+++ b/components/media-feature/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "media-feature",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "namespace": "stanford-components",
   "description": "THe media feature component is used to feature a singluar podcast or book.",
   "displayName": "Media Feature",

--- a/components/media-feature/manifest.json
+++ b/components/media-feature/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "media-feature",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "namespace": "stanford-components",
   "description": "THe media feature component is used to feature a singluar podcast or book.",
   "displayName": "Media Feature",

--- a/components/media-feature/manifest.json
+++ b/components/media-feature/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "media-feature",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "namespace": "stanford-components",
   "description": "THe media feature component is used to feature a singluar podcast or book.",
   "displayName": "Media Feature",

--- a/components/media-feature/manifest.json
+++ b/components/media-feature/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "media-feature",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "namespace": "stanford-components",
   "description": "THe media feature component is used to feature a singluar podcast or book.",
   "displayName": "Media Feature",

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -1928,8 +1928,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-media-feature-title-link:hover{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity));text-decoration-line:underline}
 .su-media-feature-title-link:focus{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity));text-decoration-line:underline}
 :is(.su-dark .su-media-feature-title-link){--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-:is(.su-dark .su-media-feature-title-link:hover){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-:is(.su-dark .su-media-feature-title-link:focus){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .su-media-feature-title-link:hover){--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
+:is(.su-dark .su-media-feature-title-link:focus){--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 @media (min-width: 992px){
 [data-component="media-carousel"] .su-component-container .component-slider{margin-left:auto;margin-right:auto}}
 [data-component="media-carousel"] .swiper-slide-visible .su-media-card-thumb{transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
@@ -2141,11 +2141,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mt-2{margin-top:3.6rem}}
 @media (min-width: 1500px){
 .su-rs-mt-2{margin-top:3.8rem}}
-.su-rs-pt-2{padding-top:3rem;}
-@media (min-width: 768px){
-.su-rs-pt-2{padding-top:3.6rem}}
-@media (min-width: 1500px){
-.su-rs-pt-2{padding-top:3.8rem}}
 .su-rs-mb-2{margin-bottom:3rem;}
 @media (min-width: 768px){
 .su-rs-mb-2{margin-bottom:3.6rem}}
@@ -2246,11 +2241,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mb-6{margin-bottom:9rem}}
 @media (min-width: 1500px){
 .su-rs-mb-6{margin-bottom:9.5rem}}
-.su-rs-pb-6{padding-bottom:4.5rem;}
-@media (min-width: 768px){
-.su-rs-pb-6{padding-bottom:9rem}}
-@media (min-width: 1500px){
-.su-rs-pb-6{padding-bottom:9.5rem}}
 .su-rs-py-6{padding-top:4.5rem;padding-bottom:4.5rem;}
 @media (min-width: 768px){
 .su-rs-py-6{padding-top:9rem;padding-bottom:9rem}}
@@ -2341,11 +2331,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mt-neg1{margin-top:1.2rem}}
 @media (min-width: 1500px){
 .su-rs-mt-neg1{margin-top:1.3rem}}
-.su-type-6{font-size:2.31em;letter-spacing:-0.020em;}
-@media (min-width: 768px){
-.su-type-6{font-size:2.99em}}
-@media (min-width: 992px){
-.su-type-6{font-size:3.81em}}
 .su-type-5{font-size:2.01em;letter-spacing:-0.018em;}
 @media (min-width: 768px){
 .su-type-5{font-size:2.49em}}
@@ -2366,7 +2351,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-type-1{font-size:1.20em}}
 @media (min-width: 992px){
 .su-type-1{font-size:1.25em}}
-.su-fluid-type-6{font-size:clamp(4.2rem, 4.04vw + 2.75rem, 8.8rem)}
 .su-intro-text{font-size:1.32em;letter-spacing:-0.012em;}
 @media (min-width: 768px){
 .su-intro-text{font-size:1.44em}}
@@ -2400,17 +2384,19 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\!su-absolute{position:absolute !important}
 .su-absolute{position:absolute}
 .su-relative{position:relative}
-.su-sticky{position:sticky}
 .su-inset-0{inset:0}
-.su--bottom-1{bottom:-0.1rem}
 .su--left-80{left:-8rem}
 .su-bottom-0{bottom:0}
+.su-bottom-100{bottom:10rem}
 .su-bottom-13{bottom:1.3rem}
 .su-bottom-20{bottom:2rem}
 .su-bottom-27{bottom:2.7rem}
+.su-bottom-34{bottom:3.4rem}
 .su-bottom-38{bottom:3.8rem}
 .su-bottom-4{bottom:0.4rem}
 .su-bottom-\[-100px\]{bottom:-100px}
+.su-bottom-\[13px\]{bottom:13px}
+.su-bottom-\[27px\]{bottom:27px}
 .su-left-0{left:0}
 .su-left-1{left:0.1rem}
 .su-left-1\/2{left:50%}
@@ -2418,10 +2404,16 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-left-20{left:2rem}
 .su-left-27{left:2.7rem}
 .su-left-3{left:0.3rem}
+.su-left-32{left:3.2rem}
 .su-left-38{left:3.8rem}
 .su-left-8{left:0.8rem}
 .su-left-9{left:0.9rem}
+.su-left-\[13px\]{left:13px}
+.su-left-\[27px\]{left:27px}
+.su-left-\[3px\]{left:3px}
 .su-left-\[50\%\]{left:50%}
+.su-left-\[8px\]{left:8px}
+.su-left-\[9px\]{left:9px}
 .su-right-0{right:0}
 .su-right-1{right:0.1rem}
 .su-right-1\/2{right:50%}
@@ -2431,6 +2423,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-right-48{right:4.8rem}
 .su-right-60{right:6rem}
 .su-right-70{right:7rem}
+.su-right-auto{right:auto}
 .su-top-0{top:0}
 .su-top-1{top:0.1rem}
 .su-top-1\/2{top:50%}
@@ -2445,8 +2438,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-top-9{top:0.9rem}
 .su-top-\[-1\%\]{top:-1%}
 .su-top-\[1\.75em\]{top:1.75em}
+.su-top-\[3px\]{top:3px}
 .su-top-\[50\%\]{top:50%}
+.su-top-\[7px\]{top:7px}
 .su-top-\[80px\]{top:80px}
+.su-top-\[9px\]{top:9px}
 .su-top-auto{top:auto}
 .\!su-z-\[1\]{z-index:1 !important}
 .su-z-0{z-index:0}
@@ -2497,7 +2493,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-my-76{margin-top:7.6rem;margin-bottom:7.6rem}
 .su-my-auto{margin-top:auto;margin-bottom:auto}
 .\!su-mb-0{margin-bottom:0 !important}
-.-su-mt-500{margin-top:-50rem}
+.-su-mt-48{margin-top:-4.8rem}
 .-su-mt-\[16\.2rem\]{margin-top:-16.2rem}
 .su--ml-1em{margin-left:-1em}
 .su--ml-44{margin-left:-4.4rem}
@@ -2525,7 +2521,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mb-38{margin-bottom:3.8rem}
 .su-mb-41{margin-bottom:4.1rem}
 .su-mb-45{margin-bottom:4.5rem}
-.su-mb-450{margin-bottom:45rem}
 .su-mb-5{margin-bottom:0.5rem}
 .su-mb-58{margin-bottom:5.8rem}
 .su-mb-6{margin-bottom:0.6rem}
@@ -2536,11 +2531,16 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mb-\[-1\.75em\]{margin-bottom:-1.75em}
 .su-mb-\[-3px\]{margin-bottom:-3px}
 .su-mb-\[0px\]{margin-bottom:0px}
+.su-mb-\[13px\]{margin-bottom:13px}
+.su-mb-\[15px\]{margin-bottom:15px}
+.su-mb-\[20px\]{margin-bottom:20px}
 .su-mb-\[3\.2rem\]{margin-bottom:3.2rem}
+.su-mb-\[5px\]{margin-bottom:5px}
 .su-mb-auto{margin-bottom:auto}
 .su-ml-0{margin-left:0}
 .su-ml-04em{margin-left:0.4em}
 .su-ml-05em{margin-left:0.5em}
+.su-ml-06em{margin-left:0.6em}
 .su-ml-1{margin-left:0.1rem}
 .su-ml-13{margin-left:1.3rem}
 .su-ml-19{margin-left:1.9rem}
@@ -2549,9 +2549,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-ml-4{margin-left:0.4rem}
 .su-ml-5{margin-left:0.5rem}
 .su-ml-8{margin-left:0.8rem}
-.su-ml-80{margin-left:8rem}
 .su-ml-\[-\.5rem\]{margin-left:-.5rem}
 .su-ml-\[-3px\]{margin-left:-3px}
+.su-ml-\[-42px\]{margin-left:-42px}
 .su-ml-auto{margin-left:auto}
 .su-mr-0{margin-right:0}
 .su-mr-02em{margin-right:0.2em}
@@ -2599,11 +2599,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mt-\[-63px\]{margin-top:-63px}
 .su-mt-\[-6px\]{margin-top:-6px}
 .su-mt-\[1\.5rem\]{margin-top:1.5rem}
+.su-mt-\[15px\]{margin-top:15px}
 .su-mt-\[23\.65px\]{margin-top:23.65px}
 .su-mt-\[3\.2rem\]{margin-top:3.2rem}
 .su-mt-\[71px\]{margin-top:71px}
+.su-mt-\[9px\]{margin-top:9px}
 .su-mt-auto{margin-top:auto}
-.su-box-border{box-sizing:border-box}
 .su-block{display:block}
 .su-inline-block{display:inline-block}
 .su-inline{display:inline}
@@ -2613,12 +2614,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-aspect-\[1\/1\]{aspect-ratio:1/1}
 .su-aspect-\[16\/9\]{aspect-ratio:16/9}
 .su-aspect-\[3\/2\]{aspect-ratio:3/2}
+.su-aspect-\[9\/16\]{aspect-ratio:9/16}
 .su-size-100{width:10rem;height:10rem}
 .su-size-13{width:1.3rem;height:1.3rem}
 .su-size-14{width:1.4rem;height:1.4rem}
 .su-size-150{width:15rem;height:15rem}
 .su-size-16{width:1.6rem;height:1.6rem}
-.su-size-160{width:16rem;height:16rem}
 .su-size-18{width:1.8rem;height:1.8rem}
 .su-size-1em{width:1em;height:1em}
 .su-size-20{width:2rem;height:2rem}
@@ -2634,7 +2635,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-0{height:0}
 .su-h-1{height:0.1rem}
 .su-h-2{height:0.2rem}
-.su-h-20{height:2rem}
 .su-h-21{height:2.1rem}
 .su-h-28{height:2.8rem}
 .su-h-3{height:0.3rem}
@@ -2642,7 +2642,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-35{height:3.5rem}
 .su-h-4{height:0.4rem}
 .su-h-40{height:4rem}
-.su-h-42{height:4.2rem}
 .su-h-43{height:4.3rem}
 .su-h-44{height:4.4rem}
 .su-h-45{height:4.5rem}
@@ -2654,10 +2653,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-72{height:7.2rem}
 .su-h-9{height:0.9rem}
 .su-h-90{height:9rem}
-.su-h-\[100vh\]{height:100vh}
 .su-h-\[101\%\]{height:101%}
+.su-h-\[150px\]{height:150px}
 .su-h-\[165px\]{height:165px}
 .su-h-\[18\.6rem\]{height:18.6rem}
+.su-h-\[200px\]{height:200px}
 .su-h-\[218px\]{height:218px}
 .su-h-\[224px\]{height:224px}
 .su-h-\[233px\]{height:233px}
@@ -2665,8 +2665,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-\[2px\]{height:2px}
 .su-h-\[300px\]{height:300px}
 .su-h-\[34\.2rem\]{height:34.2rem}
+.su-h-\[342px\]{height:342px}
+.su-h-\[4px\]{height:4px}
 .su-h-\[5\.6rem\]{height:5.6rem}
-.su-h-\[56\.25vw\]{height:56.25vw}
+.su-h-\[50px\]{height:50px}
 .su-h-\[56px\]{height:56px}
 .su-h-\[60\%\]{height:60%}
 .su-h-\[66px\]{height:66px}
@@ -2686,7 +2688,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-max-h-70{max-height:7rem}
 .su-max-h-\[103px\]{max-height:103px}
 .su-min-h-\[56px\]{min-height:56px}
-.su-min-h-full{min-height:100%}
 .su-w-08em{width:0.8em}
 .su-w-1{width:0.1rem}
 .su-w-1\/2{width:50%}
@@ -2705,7 +2706,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-w-4{width:0.4rem}
 .su-w-40{width:4rem}
 .su-w-41{width:4.1rem}
-.su-w-42{width:4.2rem}
 .su-w-44{width:4.4rem}
 .su-w-5{width:0.5rem}
 .su-w-5\/6{width:83.333333%}
@@ -2719,13 +2719,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-w-\[10\%\]{width:10%}
 .su-w-\[100\%\]{width:100%}
 .su-w-\[103px\]{width:103px}
+.su-w-\[150px\]{width:150px}
 .su-w-\[16\.66\%\]{width:16.66%}
 .su-w-\[165px\]{width:165px}
-.su-w-\[177\.77777778vh\]{width:177.77777778vh}
+.su-w-\[200px\]{width:200px}
 .su-w-\[218px\]{width:218px}
 .su-w-\[22\.6rem\]{width:22.6rem}
 .su-w-\[224px\]{width:224px}
 .su-w-\[2px\]{width:2px}
+.su-w-\[50px\]{width:50px}
 .su-w-\[56px\]{width:56px}
 .su-w-\[73px\]{width:73px}
 .su-w-\[83\.333\%\]{width:83.333%}
@@ -2741,14 +2743,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-min-w-\[165px\]{min-width:165px}
 .su-min-w-\[218px\]{min-width:218px}
 .su-min-w-\[24\.9rem\]{min-width:24.9rem}
+.su-min-w-\[249px\]{min-width:249px}
 .su-min-w-\[56px\]{min-width:56px}
 .su-min-w-full{min-width:100%}
-.su-max-w-1000{max-width:100rem}
-.su-max-w-1200{max-width:120rem}
 .su-max-w-1500{max-width:150rem}
 .su-max-w-160{max-width:16rem}
 .su-max-w-700{max-width:70rem}
-.su-max-w-800{max-width:80rem}
 .su-max-w-900{max-width:90rem}
 .su-max-w-\[1026px\]{max-width:1026px}
 .su-max-w-\[103px\]{max-width:103px}
@@ -2776,7 +2776,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-flex-grow{flex-grow:1}
 .su-grow{flex-grow:1}
 .su-basis-1{flex-basis:0.1rem}
-.su-basis-auto{flex-basis:auto}
+.su-basis-4{flex-basis:0.4rem}
 .-su-translate-x-1{--tw-translate-x:-0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .-su-translate-x-1\/2{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .-su-translate-y-1{--tw-translate-y:-0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -2789,6 +2789,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-translate-x-03em{--tw-translate-x:0.3em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-1em{--tw-translate-x:1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-\[-50\%\]{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-translate-x-\[42px\]{--tw-translate-x:42px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-0{--tw-translate-y:0;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-1{--tw-translate-y:0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-\[-110px\]{--tw-translate-y:-110px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -2798,6 +2799,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rotate-90{--tw-rotate:90deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-rotate-\[-90deg\]{--tw-rotate:-90deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-scale-110{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-transform{transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-cursor-pointer{cursor:pointer}
 .su-list-none{list-style-type:none}
 .su-grid-cols-1{grid-template-columns:repeat(1, minmax(0, 1fr))}
@@ -2842,7 +2844,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-26{gap:2.6rem}
 .su-gap-27{gap:2.7rem}
 .su-gap-29{gap:2.9rem}
-.su-gap-2xl{gap:48px}
 .su-gap-3{gap:0.3rem}
 .su-gap-30{gap:3rem}
 .su-gap-32{gap:3.2rem}
@@ -2851,7 +2852,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-38{gap:3.8rem}
 .su-gap-40{gap:4rem}
 .su-gap-42{gap:4.2rem}
-.su-gap-44{gap:4.4rem}
 .su-gap-45{gap:4.5rem}
 .su-gap-48{gap:4.8rem}
 .su-gap-5{gap:0.5rem}
@@ -2866,10 +2866,20 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-\[0\.6rem\]{gap:0.6rem}
 .su-gap-\[1\.5rem\]{gap:1.5rem}
 .su-gap-\[1\.8rem\]{gap:1.8rem}
+.su-gap-\[10px\]{gap:10px}
+.su-gap-\[11px\]{gap:11px}
 .su-gap-\[18px\]{gap:18px}
+.su-gap-\[19px\]{gap:19px}
 .su-gap-\[2\.1rem\]{gap:2.1rem}
+.su-gap-\[20px\]{gap:20px}
+.su-gap-\[27px\]{gap:27px}
+.su-gap-\[2px\]{gap:2px}
+.su-gap-\[34px\]{gap:34px}
+.su-gap-\[5px\]{gap:5px}
 .su-gap-\[68px\]{gap:68px}
+.su-gap-\[6px\]{gap:6px}
 .su-gap-\[7px\]{gap:7px}
+.su-gap-\[9px\]{gap:9px}
 .su-gap-px{gap:1px}
 .su-gap-x-13{column-gap:1.3rem}
 .su-gap-x-16{column-gap:1.6rem}
@@ -2881,6 +2891,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-x-31{column-gap:3.1em}
 .su-gap-x-40{column-gap:4rem}
 .su-gap-x-\[0\.691rem\]{column-gap:0.691rem}
+.su-gap-x-\[13px\]{column-gap:13px}
 .su-gap-y-0{row-gap:0}
 .su-gap-y-11{row-gap:1.1rem}
 .su-gap-y-12{row-gap:1.2rem}
@@ -2904,7 +2915,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-ellipsis{text-overflow:ellipsis}
 .su-whitespace-nowrap{white-space:nowrap}
 .su-whitespace-pre-line{white-space:pre-line}
-.su-text-balance{text-wrap:balance}
 .su-break-words{overflow-wrap:break-word}
 .su-rounded{border-radius:0.3rem}
 .su-rounded-\[100px\]{border-radius:100px}
@@ -2919,11 +2929,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-border-b{border-bottom-width:1px}
 .su-border-b-2{border-bottom-width:2px}
 .su-border-b-4{border-bottom-width:4px}
-.su-border-l{border-left-width:1px}
 .su-border-l-2{border-left-width:2px}
 .su-border-l-5{border-left-width:5px}
 .su-border-r{border-right-width:1px}
 .su-border-t{border-top-width:1px}
+.su-border-solid{border-style:solid}
 .su-border-none{border-style:none}
 .su-border-black{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
 .su-border-black-10{--tw-border-opacity:1;border-color:rgb(234 234 234 / var(--tw-border-opacity))}
@@ -2950,6 +2960,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bg-black-30{--tw-bg-opacity:1;background-color:rgb(192 192 191 / var(--tw-bg-opacity))}
 .su-bg-black-40{--tw-bg-opacity:1;background-color:rgb(171 171 169 / var(--tw-bg-opacity))}
 .su-bg-black-true{--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
+.su-bg-black-true\/75{background-color:rgb(0 0 0 / 0.75)}
 .su-bg-black\/\[0\.33\]{background-color:rgb(46 45 41 / 0.33)}
 .su-bg-digital-green-dark{--tw-bg-opacity:1;background-color:rgb(0 111 84 / var(--tw-bg-opacity))}
 .su-bg-digital-red{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
@@ -2965,12 +2976,16 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bg-gradient-to-t{background-image:linear-gradient(to top, var(--tw-gradient-stops))}
 .su-from-black-true{--tw-gradient-from:#000000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-black-true\/75{--tw-gradient-from:rgb(0 0 0 / 0.75) var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
+.su-from-black-true\/80{--tw-gradient-from:rgb(0 0 0 / 0.8) var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-digital-red{--tw-gradient-from:#B1040E var(--tw-gradient-from-position);--tw-gradient-to:rgb(177 4 14 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-digital-red-dark{--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-digital-red-light{--tw-gradient-from:#E50808 var(--tw-gradient-from-position);--tw-gradient-to:rgb(229 8 8 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-white{--tw-gradient-from:#fff var(--tw-gradient-from-position);--tw-gradient-to:rgb(255 255 255 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-via-\[rgb\(255_255_255\/\.5\)_8\%\]{--tw-gradient-to:rgb(255 255 255 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(255 255 255/.5) 8% var(--tw-gradient-via-position), var(--tw-gradient-to)}
+.su-via-black-true{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #000000 var(--tw-gradient-via-position), var(--tw-gradient-to)}
+.su-via-black-true\/60{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(0 0 0 / 0.6) var(--tw-gradient-via-position), var(--tw-gradient-to)}
 .su-via-digital-red-light{--tw-gradient-to:rgb(229 8 8 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #E50808 var(--tw-gradient-via-position), var(--tw-gradient-to)}
+.su-via-30\%{--tw-gradient-via-position:30%}
 .su-to-black-true{--tw-gradient-to:#000000 var(--tw-gradient-to-position)}
 .su-to-black-true\/60{--tw-gradient-to:rgb(0 0 0 / 0.6) var(--tw-gradient-to-position)}
 .su-to-cardinal-red-dark{--tw-gradient-to:#820000 var(--tw-gradient-to-position)}
@@ -3010,11 +3025,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-p-48{padding:4.8rem}
 .su-p-7{padding:0.7rem}
 .su-p-9{padding:0.9rem}
+.su-p-\[3px\]{padding:3px}
+.su-p-\[7px\]{padding:7px}
+.su-p-\[9px\]{padding:9px}
 .su-px-0{padding-left:0;padding-right:0}
 .su-px-20{padding-left:2rem;padding-right:2rem}
 .su-px-22{padding-left:2.2rem;padding-right:2.2rem}
 .su-px-29{padding-left:2.9rem;padding-right:2.9rem}
 .su-px-30{padding-left:3rem;padding-right:3rem}
+.su-px-32{padding-left:3.2rem;padding-right:3.2rem}
 .su-px-35{padding-left:3.5rem;padding-right:3.5rem}
 .su-px-36{padding-left:3.6rem;padding-right:3.6rem}
 .su-px-38{padding-left:3.8rem;padding-right:3.8rem}
@@ -3023,6 +3042,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-px-5{padding-left:0.5rem;padding-right:0.5rem}
 .su-px-50{padding-left:5rem;padding-right:5rem}
 .su-px-65{padding-left:6.5rem;padding-right:6.5rem}
+.su-px-\[20px\]{padding-left:20px;padding-right:20px}
 .su-py-0{padding-top:0;padding-bottom:0}
 .su-py-10{padding-top:1rem;padding-bottom:1rem}
 .su-py-15{padding-top:1.5rem;padding-bottom:1.5rem}
@@ -3069,7 +3089,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pl-15{padding-left:1.5rem}
 .su-pl-170{padding-left:17rem}
 .su-pl-20{padding-left:2rem}
-.su-pl-200{padding-left:20rem}
 .su-pl-25{padding-left:2.5rem}
 .su-pl-27{padding-left:2.7rem}
 .su-pl-30{padding-left:3rem}
@@ -3078,6 +3097,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pl-39{padding-left:3.9rem}
 .su-pl-48{padding-left:4.8rem}
 .su-pl-50{padding-left:5rem}
+.su-pl-\[39px\]{padding-left:39px}
 .su-pl-\[calc\(16\.666\%\+10px\)\]{padding-left:calc(16.666% + 10px)}
 .su-pr-0{padding-right:0}
 .su-pr-10{padding-right:1rem}
@@ -3143,14 +3163,21 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-\[1\.5rem\]{font-size:1.5rem}
 .su-text-\[1\.8rem\]{font-size:1.8rem}
 .su-text-\[14px\]{font-size:14px}
+.su-text-\[16px\]{font-size:16px}
+.su-text-\[18px\]{font-size:18px}
+.su-text-\[19px\]{font-size:19px}
 .su-text-\[2\.0rem\]{font-size:2.0rem}
 .su-text-\[2\.4rem\]{font-size:2.4rem}
+.su-text-\[20px\]{font-size:20px}
+.su-text-\[21px\]{font-size:21px}
+.su-text-\[24px\]{font-size:24px}
+.su-text-\[28px\]{font-size:28px}
 .su-text-\[3\.5rem\]{font-size:3.5rem}
+.su-text-\[3\.6rem\]{font-size:3.6rem}
 .su-text-\[33px\]{font-size:33px}
 .su-text-\[35px\]{font-size:35px}
 .su-text-\[39px\]{font-size:39px}
 .su-text-\[3rem\]{font-size:3rem}
-.su-text-\[4\.5rem\]{font-size:4.5rem}
 .su-text-\[4\.6rem\]{font-size:4.6rem}
 .su-text-\[4\.8rem\]{font-size:4.8rem}
 .su-text-\[40px\]{font-size:40px}
@@ -3174,10 +3201,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-leading-\[1\.6rem\]{line-height:1.6rem}
 .su-leading-\[119\.4\%\]{line-height:119.4%}
 .su-leading-\[119\.415\%\]{line-height:119.415%}
+.su-leading-\[120\%\]{line-height:120%}
 .su-leading-\[125\%\]{line-height:125%}
 .su-leading-\[125\.28\%\]{line-height:125.28%}
 .su-leading-\[130\%\]{line-height:130%}
 .su-leading-\[130\.245\%\]{line-height:130.245%}
+.su-leading-\[150\%\]{line-height:150%}
 .su-leading-\[16\.72px\]{line-height:16.72px}
 .su-leading-\[16px\]{line-height:16px}
 .su-leading-\[17\.5px\]{line-height:17.5px}
@@ -3222,6 +3251,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-leading-tight{line-height:1.1}
 .su-tracking-normal{letter-spacing:0em}
 .\!su-text-digital-red{--tw-text-opacity:1 !important;color:rgb(177 4 14 / var(--tw-text-opacity)) !important}
+.su-text-\[white\]{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .su-text-black{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
 .su-text-black-40{--tw-text-opacity:1;color:rgb(171 171 169 / var(--tw-text-opacity))}
 .su-text-black-50{--tw-text-opacity:1;color:rgb(151 150 148 / var(--tw-text-opacity))}
@@ -3241,10 +3271,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-no-underline{text-decoration-line:none}
 .su-decoration-dark-mode-red{text-decoration-color:#EC0909}
 .su-decoration-2{text-decoration-thickness:2px}
-.su-decoration-\[0\.12em\]{text-decoration-thickness:0.12em}
 .su-decoration-\[3px\]{text-decoration-thickness:3px}
 .su-underline-offset-4{text-underline-offset:4px}
-.su-underline-offset-\[3px\]{text-underline-offset:3px}
 .su-opacity-0{opacity:0}
 .su-opacity-100{opacity:1}
 .su-opacity-25{opacity:0.25}
@@ -3924,6 +3952,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\*\:su-h-\[40px\] > *{height:40px}
 .\*\:su-w-\[40px\] > *{width:40px}
 .\*\:su-w-full > *{width:100%}
+.\*\:su-max-w-\[45rem\] > *{max-width:45rem}
+.\*\:su-basis-4\/5 > *{flex-basis:80%}
 .\*\:su-font-sans > *{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif}
 .\*\:su-text-16 > *{font-size:1.6rem}
 .\*\:su-text-18 > *{font-size:1.8rem}
@@ -3971,11 +4001,14 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .before\:su--mt-25::before{content:var(--tw-content);margin-top:-2.5rem}
 .before\:su--mt-30::before{content:var(--tw-content);margin-top:-3rem}
 .before\:su-mr-6::before{content:var(--tw-content);margin-right:0.6rem}
+.before\:su-mr-\[6px\]::before{content:var(--tw-content);margin-right:6px}
+.before\:su-mt-\[-25px\]::before{content:var(--tw-content);margin-top:-25px}
 .before\:su-block::before{content:var(--tw-content);display:block}
 .before\:su-h-1::before{content:var(--tw-content);height:0.1rem}
 .before\:su-h-15::before{content:var(--tw-content);height:1.5rem}
 .before\:su-h-2::before{content:var(--tw-content);height:0.2rem}
 .before\:su-h-4::before{content:var(--tw-content);height:0.4rem}
+.before\:su-h-\[1px\]::before{content:var(--tw-content);height:1px}
 .before\:su-h-\[4\.5px\]::before{content:var(--tw-content);height:4.5px}
 .before\:su-h-full::before{content:var(--tw-content);height:100%}
 .before\:su-h-px::before{content:var(--tw-content);height:1px}
@@ -4069,10 +4102,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .aria-pressed\:su-bg-transparent[aria-pressed="true"]{background-color:transparent}
 .aria-pressed\:su-text-white[aria-pressed="true"]{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .su-group\/front[aria-hidden="true"] .group-aria-hidden\/front\:su-opacity-0{opacity:0}
-.hocus\:su-scale-110:hover{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
-@keyframes su-pulse{
-50%{opacity:.5}}
-.hocus\:su-animate-pulse:hover{animation:su-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite}
 .hocus\:su-border-black:hover{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
 .hocus\:su-border-digital-blue-vivid:hover{--tw-border-opacity:1;border-color:rgb(5 151 255 / var(--tw-border-opacity))}
 .hocus\:su-border-digital-green-bright:hover{--tw-border-opacity:1;border-color:rgb(0 155 118 / var(--tw-border-opacity))}
@@ -4083,7 +4112,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .hocus\:su-bg-digital-red:hover{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
 .hocus\:su-bg-none:hover{background-image:none}
 .hocus\:su-text-black:hover{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-.hocus\:su-text-dark-mode-red:hover{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .hocus\:su-text-digital-red:hover{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .hocus\:su-text-white:hover{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .hocus\:su-text-white\/95:hover{color:rgb(255 255 255 / 0.95)}
@@ -4091,10 +4119,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .hocus\:su-no-underline:hover{text-decoration-line:none}
 .hocus\:su-decoration-white:hover{text-decoration-color:#fff}
 .hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(177\2c 4\2c 14\2c 1\)\]:hover{--tw-shadow:inset 0 0 0 3px rgba(177,4,14,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
-.hocus\:su-scale-110:focus{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
-@keyframes su-pulse{
-50%{opacity:.5}}
-.hocus\:su-animate-pulse:focus{animation:su-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite}
 .hocus\:su-border-black:focus{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
 .hocus\:su-border-digital-blue-vivid:focus{--tw-border-opacity:1;border-color:rgb(5 151 255 / var(--tw-border-opacity))}
 .hocus\:su-border-digital-green-bright:focus{--tw-border-opacity:1;border-color:rgb(0 155 118 / var(--tw-border-opacity))}
@@ -4105,7 +4129,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .hocus\:su-bg-digital-red:focus{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
 .hocus\:su-bg-none:focus{background-image:none}
 .hocus\:su-text-black:focus{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-.hocus\:su-text-dark-mode-red:focus{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .hocus\:su-text-digital-red:focus{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .hocus\:su-text-white:focus{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .hocus\:su-text-white\/95:focus{color:rgb(255 255 255 / 0.95)}
@@ -4261,6 +4284,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 :is(.su-dark .su-group:focus-within .dark\:group-hocus-within\:su-text-digital-red-light){--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 :is(.su-dark .su-group:hover .dark\:group-hocus-within\:su-text-digital-red-light){--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 @media (min-width: 576px){
+.sm\:su-bottom-120{bottom:12rem}
+.sm\:su-bottom-61{bottom:6.1rem}
+.sm\:su-left-48{left:4.8rem}
 .sm\:su-left-\[10\%\]{left:10%}
 .sm\:su-right-\[10\%\]{right:10%}
 .sm\:su-col-span-10{grid-column:span 10 / span 10}
@@ -4289,6 +4315,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .sm\:su-text-23{font-size:2.3rem}
 .sm\:su-text-24{font-size:2.4rem}
 .sm\:su-text-\[22\.5px\]{font-size:22.5px}
+.sm\:su-text-\[4\.8rem\]{font-size:4.8rem}
 .sm\:su-text-\[6\.1rem\]{font-size:6.1rem}
 .sm\:su-leading-\[27px\]{line-height:27px}
 .sm\:su-leading-\[28\.75px\]{line-height:28.75px}}
@@ -4328,9 +4355,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-mb-30{margin-bottom:3rem}
 .md\:su-mb-60{margin-bottom:6rem}
 .md\:su-mb-8{margin-bottom:0.8rem}
+.md\:su-mb-\[11px\]{margin-bottom:11px}
+.md\:su-mb-\[18px\]{margin-bottom:18px}
+.md\:su-mb-\[19px\]{margin-bottom:19px}
+.md\:su-mb-\[26px\]{margin-bottom:26px}
+.md\:su-mb-\[27px\]{margin-bottom:27px}
 .md\:su-mb-\[3px\]{margin-bottom:3px}
 .md\:su-mb-\[5\.9rem\]{margin-bottom:5.9rem}
 .md\:su-mb-\[6\.05px\]{margin-bottom:6.05px}
+.md\:su-mb-\[8px\]{margin-bottom:8px}
 .md\:su-ml-19{margin-left:1.9rem}
 .md\:su-ml-\[19px\]{margin-left:19px}
 .md\:su-ml-\[8\.333\%\]{margin-left:8.333%}
@@ -4347,6 +4380,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-mt-26{margin-top:2.6rem}
 .md\:su-mt-61{margin-top:6.1rem}
 .md\:su-mt-\[1\.9rem\]{margin-top:1.9rem}
+.md\:su-mt-\[12px\]{margin-top:12px}
+.md\:su-mt-\[26px\]{margin-top:26px}
 .md\:su-mt-\[4\.8rem\]{margin-top:4.8rem}
 .md\:su-mt-auto{margin-top:auto}
 .md\:su-block{display:block}
@@ -4354,7 +4389,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-flex{display:flex}
 .md\:su-grid{display:grid}
 .md\:su-hidden{display:none}
-.md\:su-size-200{width:20rem;height:20rem}
 .md\:su-size-50{width:5rem;height:5rem}
 .md\:su-size-70{width:7rem;height:7rem}
 .md\:su-h-3{height:0.3rem}
@@ -4367,6 +4401,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-max-h-\[168px\]{max-height:168px}
 .md\:su-max-h-\[6em\]{max-height:6em}
 .md\:su-min-h-\[38\.4rem\]{min-height:38.4rem}
+.md\:su-min-h-\[384px\]{min-height:384px}
 .md\:su-w-1\/3{width:33.333333%}
 .md\:su-w-3{width:0.3rem}
 .md\:su-w-30{width:3rem}
@@ -4388,6 +4423,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-w-auto{width:auto}
 .md\:su-min-w-\[170px\]{min-width:170px}
 .md\:su-min-w-\[17rem\]{min-width:17rem}
+.md\:su-min-w-\[249px\]{min-width:249px}
 .md\:su-min-w-\[257px\]{min-width:257px}
 .md\:su-max-w-500{max-width:50rem}
 .md\:su-max-w-\[168px\]{max-width:168px}
@@ -4427,8 +4463,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-gap-61{gap:6.1rem}
 .md\:su-gap-72{gap:7.2rem}
 .md\:su-gap-9{gap:0.9rem}
+.md\:su-gap-\[0px\]{gap:0px}
+.md\:su-gap-\[12px\]{gap:12px}
 .md\:su-gap-\[13px\]{gap:13px}
 .md\:su-gap-\[2\.5rem\]{gap:2.5rem}
+.md\:su-gap-\[36px\]{gap:36px}
+.md\:su-gap-\[48px\]{gap:48px}
+.md\:su-gap-\[72px\]{gap:72px}
 .md\:su-gap-x-20{column-gap:2rem}
 .md\:su-gap-x-24{column-gap:2.4rem}
 .md\:su-gap-x-27{column-gap:2.7rem}
@@ -4475,6 +4516,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pb-9{padding-bottom:0.9rem}
 .md\:su-pb-\[1\.3rem\]{padding-bottom:1.3rem}
 .md\:su-pb-\[10px\]{padding-bottom:10px}
+.md\:su-pb-\[13px\]{padding-bottom:13px}
 .md\:su-pb-\[14px\]{padding-bottom:14px}
 .md\:su-pb-\[16\.6rem\]{padding-bottom:16.6rem}
 .md\:su-pb-\[17\.7rem\]{padding-bottom:17.7rem}
@@ -4482,8 +4524,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pb-\[20\.05px\]{padding-bottom:20.05px}
 .md\:su-pb-\[6\.05px\]{padding-bottom:6.05px}
 .md\:su-pb-\[64px\]{padding-bottom:64px}
+.md\:su-pb-\[9px\]{padding-bottom:9px}
 .md\:su-pl-0{padding-left:0}
-.md\:su-pl-48{padding-left:4.8rem}
 .md\:su-pl-50{padding-left:5rem}
 .md\:su-pl-76{padding-left:7.6rem}
 .md\:su-pr-0{padding-right:0}
@@ -4515,15 +4557,20 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-text-\[1\.9rem\]{font-size:1.9rem}
 .md\:su-text-\[10rem\]{font-size:10rem}
 .md\:su-text-\[16px\]{font-size:16px}
+.md\:su-text-\[19px\]{font-size:19px}
 .md\:su-text-\[2\.9rem\]{font-size:2.9rem}
+.md\:su-text-\[20px\]{font-size:20px}
+.md\:su-text-\[21px\]{font-size:21px}
+.md\:su-text-\[28px\]{font-size:28px}
 .md\:su-text-\[3\.3rem\]{font-size:3.3rem}
 .md\:su-text-\[3\.6rem\]{font-size:3.6rem}
+.md\:su-text-\[35px\]{font-size:35px}
+.md\:su-text-\[36px\]{font-size:36px}
 .md\:su-text-\[4\.0rem\]{font-size:4.0rem}
 .md\:su-text-\[40px\]{font-size:40px}
 .md\:su-text-\[4rem\]{font-size:4rem}
 .md\:su-text-\[54px\]{font-size:54px}
 .md\:su-text-\[7\.2rem\]{font-size:7.2rem}
-.md\:su-text-\[7\.5rem\]{font-size:7.5rem}
 .md\:su-text-\[80px\]{font-size:80px}
 .md\:su-font-normal{font-weight:400}
 .md\:su-leading-\[1\.911rem\]{line-height:1.911rem}
@@ -4575,6 +4622,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .before\:md\:su-h-full::before{content:var(--tw-content);height:100%}
 .md\:before\:su-h-full::before{content:var(--tw-content);height:100%}
 .before\:md\:su-w-1::before{content:var(--tw-content);width:0.1rem}
+.before\:md\:su-w-\[1px\]::before{content:var(--tw-content);width:1px}
 .before\:md\:su-w-full::before{content:var(--tw-content);width:100%}
 .before\:md\:su-w-px::before{content:var(--tw-content);width:1px}
 .md\:before\:su-w-\[26\%\]::before{content:var(--tw-content);width:26%}
@@ -4592,8 +4640,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 @media (min-width: 992px){
 .lg\:su-relative{position:relative}
 .lg\:su-bottom-0{bottom:0}
+.lg\:su-bottom-34{bottom:3.4rem}
 .lg\:su-bottom-38{bottom:3.8rem}
+.lg\:su-bottom-80{bottom:8rem}
 .lg\:su-bottom-\[15\.5rem\]{bottom:15.5rem}
+.lg\:su-left-32{left:3.2rem}
 .lg\:su-left-38{left:3.8rem}
 .lg\:su-right-0{right:0}
 .lg\:su-top-0{top:0}
@@ -4623,7 +4674,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-mb-8{margin-bottom:0.8rem}
 .lg\:su-mb-9{margin-bottom:0.9rem}
 .lg\:su-mb-\[104px\]{margin-bottom:104px}
+.lg\:su-mb-\[12px\]{margin-bottom:12px}
+.lg\:su-mb-\[15px\]{margin-bottom:15px}
+.lg\:su-mb-\[19px\]{margin-bottom:19px}
 .lg\:su-mb-\[2\.25px\]{margin-bottom:2.25px}
+.lg\:su-mb-\[38px\]{margin-bottom:38px}
 .lg\:su-mb-\[4px\]{margin-bottom:4px}
 .lg\:su-ml-0{margin-left:0}
 .lg\:su-ml-26{margin-left:2.6rem}
@@ -4651,6 +4706,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-mt-\[-131px\]{margin-top:-131px}
 .lg\:su-mt-\[0px\]{margin-top:0px}
 .lg\:su-mt-\[19\.5px\]{margin-top:19.5px}
+.lg\:su-mt-\[29px\]{margin-top:29px}
 .lg\:su-block{display:block}
 .lg\:su-inline-block{display:inline-block}
 .lg\:su-flex{display:flex}
@@ -4661,9 +4717,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-h-9{height:0.9rem}
 .lg\:su-h-\[193px\]{height:193px}
 .lg\:su-h-\[292px\]{height:292px}
+.lg\:su-h-\[373px\]{height:373px}
 .lg\:su-h-\[378\.331px\]{height:378.331px}
 .lg\:su-h-\[4px\]{height:4px}
 .lg\:su-h-\[57\.2rem\]{height:57.2rem}
+.lg\:su-h-\[572px\]{height:572px}
 .lg\:su-h-\[764px\]{height:764px}
 .lg\:su-h-\[871\.33px\]{height:871.33px}
 .lg\:su-h-\[calc\(100\%\+15\.5rem\+1em\)\]{height:calc(100% + 15.5rem + 1em)}
@@ -4685,6 +4743,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-w-\[calc\(50\%-1\.9rem\)\]{width:calc(50% - 1.9rem)}
 .lg\:su-w-full{width:100%}
 .lg\:su-min-w-\[38\.2rem\]{min-width:38.2rem}
+.lg\:su-min-w-\[382px\]{min-width:382px}
 .lg\:su-max-w-800{max-width:80rem}
 .lg\:su-max-w-\[185px\]{max-width:185px}
 .lg\:su-max-w-\[29\.2rem\]{max-width:29.2rem}
@@ -4692,6 +4751,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-max-w-\[296px\]{max-width:296px}
 .lg\:su-max-w-\[35\.9rem\]{max-width:35.9rem}
 .lg\:su-max-w-\[38\.2rem\]{max-width:38.2rem}
+.lg\:su-max-w-\[382px\]{max-width:382px}
 .lg\:su-max-w-\[50\%\]{max-width:50%}
 .lg\:su-max-w-\[63\.6rem\]{max-width:63.6rem}
 .lg\:su-max-w-\[633px\]{max-width:633px}
@@ -4707,7 +4767,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-grid-cols-3{grid-template-columns:repeat(3, minmax(0, 1fr))}
 .lg\:su-grid-cols-4{grid-template-columns:repeat(4, minmax(0, 1fr))}
 .lg\:su-flex-row{flex-direction:row}
-.lg\:su-flex-row-reverse{flex-direction:row-reverse}
 .lg\:su-flex-col{flex-direction:column}
 .lg\:su-flex-wrap{flex-wrap:wrap}
 .lg\:su-flex-nowrap{flex-wrap:nowrap}
@@ -4729,9 +4788,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-gap-61{gap:6.1rem}
 .lg\:su-gap-9{gap:0.9rem}
 .lg\:su-gap-\[102px\]{gap:102px}
+.lg\:su-gap-\[12px\]{gap:12px}
+.lg\:su-gap-\[13px\]{gap:13px}
 .lg\:su-gap-\[160px\]{gap:160px}
 .lg\:su-gap-\[36px\]{gap:36px}
+.lg\:su-gap-\[48px\]{gap:48px}
 .lg\:su-gap-\[76px\]{gap:76px}
+.lg\:su-gap-\[9px\]{gap:9px}
 .lg\:su-gap-x-20{column-gap:2rem}
 .lg\:su-gap-x-27{column-gap:2.7rem}
 .lg\:su-gap-x-40{column-gap:4rem}
@@ -4754,6 +4817,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-py-30{padding-top:3rem;padding-bottom:3rem}
 .lg\:su-py-36{padding-top:3.6rem;padding-bottom:3.6rem}
 .lg\:su-py-61{padding-top:6.1rem;padding-bottom:6.1rem}
+.lg\:su-py-\[30px\]{padding-top:30px;padding-bottom:30px}
 .lg\:su-pb-0{padding-bottom:0}
 .lg\:su-pb-16{padding-bottom:1.6rem}
 .lg\:su-pb-27{padding-bottom:2.7rem}
@@ -4793,13 +4857,21 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-text-23{font-size:2.3rem}
 .lg\:su-text-24{font-size:2.4rem}
 .lg\:su-text-\[128px\]{font-size:128px}
+.lg\:su-text-\[16px\]{font-size:16px}
+.lg\:su-text-\[18px\]{font-size:18px}
 .lg\:su-text-\[2\.1rem\]{font-size:2.1rem}
 .lg\:su-text-\[2\.8rem\]{font-size:2.8rem}
+.lg\:su-text-\[20px\]{font-size:20px}
+.lg\:su-text-\[21px\]{font-size:21px}
+.lg\:su-text-\[23px\]{font-size:23px}
+.lg\:su-text-\[24px\]{font-size:24px}
+.lg\:su-text-\[3\.6rem\]{font-size:3.6rem}
 .lg\:su-text-\[32px\]{font-size:32px}
 .lg\:su-text-\[33px\]{font-size:33px}
 .lg\:su-text-\[4\.3rem\]{font-size:4.3rem}
 .lg\:su-text-\[4\.9rem\]{font-size:4.9rem}
 .lg\:su-text-\[43px\]{font-size:43px}
+.lg\:su-text-\[48px\]{font-size:48px}
 .lg\:su-text-\[70px\]{font-size:70px}
 .lg\:su-text-\[9\.5rem\]{font-size:9.5rem}
 .lg\:su-text-\[9\.6rem\]{font-size:9.6rem}
@@ -4823,6 +4895,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\*\:lg\:su-size-100 > *{width:10rem;height:10rem}
 .\*\:lg\:su-h-\[100px\] > *{height:100px}
 .\*\:lg\:su-w-\[100px\] > *{width:100px}
+.\*\:lg\:su-basis-1\/3 > *{flex-basis:33.333333%}
 .\*\:lg\:su-text-19 > *{font-size:1.9rem}
 .lg\:\*\:su-text-21 > *{font-size:2.1rem}
 .lg\:\*\:su-text-26 > *{font-size:2.6rem}
@@ -4844,6 +4917,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:before\:su--mt-32::before{content:var(--tw-content);margin-top:-3.2rem}
 .lg\:before\:su--mt-38::before{content:var(--tw-content);margin-top:-3.8rem}
 .lg\:before\:su-mr-13::before{content:var(--tw-content);margin-right:1.3rem}
+.lg\:before\:su-mr-\[13px\]::before{content:var(--tw-content);margin-right:13px}
+.lg\:before\:su-mt-\[-38px\]::before{content:var(--tw-content);margin-top:-38px}
 .before\:lg\:su-h-full::before{content:var(--tw-content);height:100%}
 .lg\:before\:su-h-full::before{content:var(--tw-content);height:100%}
 .lg\:before\:su-h-px::before{content:var(--tw-content);height:1px}
@@ -4875,6 +4950,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .xl\:su-translate-y-\[-220px\]{--tw-translate-y:-220px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .xl\:su-grid-cols-2{grid-template-columns:repeat(2, minmax(0, 1fr))}
 .xl\:su-flex-row-reverse{flex-direction:row-reverse}
+.xl\:su-gap-40{gap:4rem}
 .xl\:su-gap-60{gap:6rem}
 .xl\:su-py-100{padding-top:10rem;padding-bottom:10rem}
 .xl\:su-pl-170{padding-left:17rem}
@@ -4883,37 +4959,62 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .xl\:su-text-\[3\.3rem\]{font-size:3.3rem}
 .xl\:su-text-\[6\.4rem\]{font-size:6.4rem}
 .xl\:su-text-\[6rem\]{font-size:6rem}
+.xl\:su-leading-snug{line-height:1.3}
 .xl\:\*\:su-leading-snug > *{line-height:1.3}}
 @media (min-width: 1500px){
+.\32xl\:su-bottom-120{bottom:12rem}
+.\32xl\:su-bottom-61{bottom:6.1rem}
+.\32xl\:su-left-48{left:4.8rem}
 .\32xl\:su--mt-58{margin-top:-5.8rem}
-.\32xl\:su-ml-80{margin-left:8rem}
 .\32xl\:su-mt-171{margin-top:17.1rem}
-.\32xl\:su-size-300{width:30rem;height:30rem}
 .\32xl\:su-basis-\[30\%\]{flex-basis:30%}
 .\32xl\:su-basis-\[70\%\]{flex-basis:70%}
 .\32xl\:su-flex-row{flex-direction:row}
 .\32xl\:su-gap-72{gap:7.2rem}
+.\32xl\:su-px-48{padding-left:4.8rem;padding-right:4.8rem}
 .\32xl\:su-px-\[17rem\]{padding-left:17rem;padding-right:17rem}
 .\32xl\:su-px-\[6\.6rem\]{padding-left:6.6rem;padding-right:6.6rem}
 .\32xl\:su-py-140{padding-top:14rem;padding-bottom:14rem}
-.\32xl\:su-pl-200{padding-left:20rem}
 .\32xl\:su-pl-76{padding-left:7.6rem}
 .\32xl\:su-text-\[2\.9rem\]{font-size:2.9rem}
-.\32xl\:su-text-\[3\.3rem\]{font-size:3.3rem}}
+.\32xl\:su-text-\[3\.3rem\]{font-size:3.3rem}
+.\32xl\:su-text-\[4\.8rem\]{font-size:4.8rem}}
 .\[\&\>\*\:last-child\]\:su-mb-0>*:last-child{margin-bottom:0}
 .\[\&\>\*\:last-child\]\:after\:su-content-\[\'\\u201D\'\]>*:last-child::after{--tw-content:'\u201D';content:var(--tw-content)}
 .\[\&\>\*\:last-child\]\:after\:su-content-\[\'\201D\'\]>*:last-child::after{--tw-content:'”';content:var(--tw-content)}
+.\[\&\>\*\]\:su-my-0>*{margin-top:0;margin-bottom:0}
+.\[\&\>\*\]\:su-mt-\[4px\]>*{margin-top:4px}
 .\[\&\>\*\]\:su-inline-block>*{display:inline-block}
 .\[\&\>\*\]\:su-h-23>*{height:2.3rem}
+.\[\&\>\*\]\:su-h-\[42px\]>*{height:42px}
 .\[\&\>\*\]\:su-w-24>*{width:2.4rem}
+.\[\&\>\*\]\:su-w-\[42px\]>*{width:42px}
+.\[\&\>\*\]\:su-w-full>*{width:100%}
 .\[\&\>\*\]\:su-translate-x-\[\.12em\]>*{--tw-translate-x:.12em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>\*\]\:su-translate-y-\[-\.08em\]>*{--tw-translate-y:-.08em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>\*\]\:su-rotate-\[-45deg\]>*{--tw-rotate:-45deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>\*\]\:su-justify-center>*{justify-content:center}
+.\[\&\>\*\]\:su-fill-transparent>*{fill:transparent}
 .\[\&\>\*\]\:su-stroke-current>*{stroke:currentColor}
 .\[\&\>\*\]\:su-stroke-digital-red>*{stroke:#B1040E}
+.\[\&\>\*\]\:su-font-sans>*{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif}
+.\[\&\>\*\]\:su-text-\[18px\]>*{font-size:18px}
+.\[\&\>\*\]\:su-text-\[19px\]>*{font-size:19px}
 .\[\&\>\*\]\:su-font-bold>*{font-weight:700}
+.\[\&\>\*\]\:su-font-normal>*{font-weight:400}
+.\[\&\>\*\]\:su-leading-\[125\%\]>*{line-height:125%}
+.\[\&\>\*\]\:su-leading-\[130\%\]>*{line-height:130%}
+.\[\&\>\*\]\:su-leading-\[22\.5px\]>*{line-height:22.5px}
+.\[\&\>\*\]\:su-leading-\[23\.75px\]>*{line-height:23.75px}
 :is(.su-dark .dark\:\[\&\>\*\]\:su-stroke-dark-mode-red>*){stroke:#EC0909}
+:is(.su-dark .\[\&\>\*\]\:dark\:su-text-white)>*{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+@media (min-width: 768px){
+.\[\&\>\*\]\:md\:su-mt-\[14px\]>*{margin-top:14px}
+.\[\&\>\*\]\:md\:su-text-\[19px\]>*{font-size:19px}
+.md\:\[\&\>\*\]\:su-text-\[19px\]>*{font-size:19px}
+.\[\&\>\*\]\:md\:su-leading-\[23\.75px\]>*{line-height:23.75px}}
+@media (min-width: 992px){
+.lg\:\[\&\>\*\]\:su-text-\[21px\]>*{font-size:21px}}
 .\[\&\>li\]\:su-m-0>li{margin:0}
 .\[\&\>p\]\:su-m-0>p{margin:0}
 .\[\&\>p\]\:\!su-mb-0>p{margin-bottom:0 !important}
@@ -4923,12 +5024,17 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:\[\&\>p\]\:\!su-text-19>p{font-size:1.9rem !important}}
 .\[\&\>svg\]\:su-mt-3>svg{margin-top:0.3rem}
 .\[\&\>svg\]\:su-h-43>svg{height:4.3rem}
+.\[\&\>svg\]\:su-h-\[40px\]>svg{height:40px}
 .\[\&\>svg\]\:su-w-41>svg{width:4.1rem}
+.\[\&\>svg\]\:su-w-\[40px\]>svg{width:40px}
 .\[\&\>svg\]\:su-translate-y-1>svg{--tw-translate-y:0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .\[\&\>svg\]\:su-text-\[4rem\]>svg{font-size:4rem}
+.\[\&\>svg\]\:su-text-\[6rem\]>svg{font-size:6rem}
 @media (min-width: 768px){
 .md\:\[\&\>svg\]\:su--mt-2>svg{margin-top:-0.2rem}
+.\[\&\>svg\]\:md\:su-h-\[60px\]>svg{height:60px}
 .md\:\[\&\>svg\]\:su-h-\[102px\]>svg{height:102px}
+.\[\&\>svg\]\:md\:su-w-\[60px\]>svg{width:60px}
 .md\:\[\&\>svg\]\:su-w-\[97px\]>svg{width:97px}
 .\[\&\>svg\]\:md\:su-text-\[6rem\]>svg{font-size:6rem}}
 @media (min-width: 992px){

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -2165,6 +2165,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mb-1{margin-bottom:2.6rem}}
 @media (min-width: 1500px){
 .su-rs-mb-1{margin-bottom:2.7rem}}
+.su-rs-pb-1{padding-bottom:2rem;}
+@media (min-width: 768px){
+.su-rs-pb-1{padding-bottom:2.6rem}}
+@media (min-width: 1500px){
+.su-rs-pb-1{padding-bottom:2.7rem}}
 .su-rs-py-1{padding-top:2rem;padding-bottom:2rem;}
 @media (min-width: 768px){
 .su-rs-py-1{padding-top:2.6rem;padding-bottom:2.6rem}}
@@ -2175,11 +2180,21 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mt-2{margin-top:3.6rem}}
 @media (min-width: 1500px){
 .su-rs-mt-2{margin-top:3.8rem}}
+.su-rs-pt-2{padding-top:3rem;}
+@media (min-width: 768px){
+.su-rs-pt-2{padding-top:3.6rem}}
+@media (min-width: 1500px){
+.su-rs-pt-2{padding-top:3.8rem}}
 .su-rs-mb-2{margin-bottom:3rem;}
 @media (min-width: 768px){
 .su-rs-mb-2{margin-bottom:3.6rem}}
 @media (min-width: 1500px){
 .su-rs-mb-2{margin-bottom:3.8rem}}
+.su-rs-pb-2{padding-bottom:3rem;}
+@media (min-width: 768px){
+.su-rs-pb-2{padding-bottom:3.6rem}}
+@media (min-width: 1500px){
+.su-rs-pb-2{padding-bottom:3.8rem}}
 .su-rs-pl-2{padding-left:3rem;}
 @media (min-width: 768px){
 .su-rs-pl-2{padding-left:3.6rem}}
@@ -2275,6 +2290,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mb-6{margin-bottom:9rem}}
 @media (min-width: 1500px){
 .su-rs-mb-6{margin-bottom:9.5rem}}
+.su-rs-pb-6{padding-bottom:4.5rem;}
+@media (min-width: 768px){
+.su-rs-pb-6{padding-bottom:9rem}}
+@media (min-width: 1500px){
+.su-rs-pb-6{padding-bottom:9.5rem}}
 .su-rs-py-6{padding-top:4.5rem;padding-bottom:4.5rem;}
 @media (min-width: 768px){
 .su-rs-py-6{padding-top:9rem;padding-bottom:9rem}}
@@ -2385,6 +2405,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-type-1{font-size:1.20em}}
 @media (min-width: 992px){
 .su-type-1{font-size:1.25em}}
+.su-fluid-type-6{font-size:clamp(4.2rem, 4.04vw + 2.75rem, 8.8rem)}
 .su-intro-text{font-size:1.32em;letter-spacing:-0.012em;}
 @media (min-width: 768px){
 .su-intro-text{font-size:1.44em}}
@@ -2412,12 +2433,14 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-basefont-23{font-size:2.1rem}}
 @media (min-width: 1500px){
 .su-basefont-23{font-size:2.3rem}}
+.su-text-shadow-lg{text-shadow:rgba(0, 0, 0, 30%) 0 0 12px}
 .su-sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0, 0, 0, 0);white-space:nowrap;border-width:0}
 .su-pointer-events-none{pointer-events:none}
 .su-fixed{position:fixed}
 .\!su-absolute{position:absolute !important}
 .su-absolute{position:absolute}
 .su-relative{position:relative}
+.su-sticky{position:sticky}
 .su-inset-0{inset:0}
 .su--left-80{left:-8rem}
 .su-bottom-0{bottom:0}
@@ -2485,6 +2508,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-z-30{z-index:30}
 .su-z-40{z-index:40}
 .su-z-50{z-index:50}
+.su-z-\[11\]{z-index:11}
 .su-z-\[1\]{z-index:1}
 .su-z-\[2\]{z-index:2}
 .su-z-\[49\]{z-index:49}
@@ -2533,6 +2557,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su--ml-44{margin-left:-4.4rem}
 .su--ml-5{margin-left:-0.5rem}
 .su--mt-2{margin-top:-0.2rem}
+.su--mt-24{margin-top:-2.4rem}
 .su--mt-50{margin-top:-5rem}
 .su-mb-0{margin-bottom:0}
 .su-mb-02em{margin-bottom:0.2em}
@@ -2632,6 +2657,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mt-9{margin-top:0.9rem}
 .su-mt-\[-63px\]{margin-top:-63px}
 .su-mt-\[-6px\]{margin-top:-6px}
+.su-mt-\[-70vh\]{margin-top:-70vh}
 .su-mt-\[1\.5rem\]{margin-top:1.5rem}
 .su-mt-\[15px\]{margin-top:15px}
 .su-mt-\[23\.65px\]{margin-top:23.65px}
@@ -2654,6 +2680,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-size-14{width:1.4rem;height:1.4rem}
 .su-size-150{width:15rem;height:15rem}
 .su-size-16{width:1.6rem;height:1.6rem}
+.su-size-160{width:16rem;height:16rem}
 .su-size-18{width:1.8rem;height:1.8rem}
 .su-size-1em{width:1em;height:1em}
 .su-size-20{width:2rem;height:2rem}
@@ -2668,6 +2695,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-size-full{width:100%;height:100%}
 .su-h-0{height:0}
 .su-h-1{height:0.1rem}
+.su-h-100{height:10rem}
 .su-h-2{height:0.2rem}
 .su-h-21{height:2.1rem}
 .su-h-28{height:2.8rem}
@@ -2685,6 +2713,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-6{height:0.6rem}
 .su-h-60{height:6rem}
 .su-h-72{height:7.2rem}
+.su-h-75{height:7.5rem}
 .su-h-9{height:0.9rem}
 .su-h-90{height:9rem}
 .su-h-\[101\%\]{height:101%}
@@ -2713,6 +2742,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-h-\[calc\(100\%-1\.25em\)\]{height:calc(100% - 1.25em)}
 .su-h-\[calc\(100\%-1em\)\]{height:calc(100% - 1em)}
 .su-h-\[calc\(100\%-2\.25em\)\]{height:calc(100% - 2.25em)}
+.su-h-\[max\(100vh\,100\%\)\]{height:max(100vh,100%)}
 .su-h-auto{height:auto}
 .su-h-full{height:100%}
 .su-h-min{height:min-content}
@@ -2722,6 +2752,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-max-h-70{max-height:7rem}
 .su-max-h-\[103px\]{max-height:103px}
 .su-min-h-\[56px\]{min-height:56px}
+.su-min-h-full{min-height:100%}
 .su-w-08em{width:0.8em}
 .su-w-1{width:0.1rem}
 .su-w-1\/2{width:50%}
@@ -2780,9 +2811,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-min-w-\[249px\]{min-width:249px}
 .su-min-w-\[56px\]{min-width:56px}
 .su-min-w-full{min-width:100%}
+.su-max-w-1000{max-width:100rem}
+.su-max-w-1200{max-width:120rem}
 .su-max-w-1500{max-width:150rem}
 .su-max-w-160{max-width:16rem}
 .su-max-w-700{max-width:70rem}
+.su-max-w-800{max-width:80rem}
 .su-max-w-900{max-width:90rem}
 .su-max-w-\[1026px\]{max-width:1026px}
 .su-max-w-\[103px\]{max-width:103px}
@@ -2886,6 +2920,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-38{gap:3.8rem}
 .su-gap-40{gap:4rem}
 .su-gap-42{gap:4.2rem}
+.su-gap-44{gap:4.4rem}
 .su-gap-45{gap:4.5rem}
 .su-gap-48{gap:4.8rem}
 .su-gap-5{gap:0.5rem}
@@ -2949,6 +2984,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-ellipsis{text-overflow:ellipsis}
 .su-whitespace-nowrap{white-space:nowrap}
 .su-whitespace-pre-line{white-space:pre-line}
+.su-text-balance{text-wrap:balance}
 .su-break-words{overflow-wrap:break-word}
 .su-rounded{border-radius:0.3rem}
 .su-rounded-\[100px\]{border-radius:100px}
@@ -2963,6 +2999,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-border-b{border-bottom-width:1px}
 .su-border-b-2{border-bottom-width:2px}
 .su-border-b-4{border-bottom-width:4px}
+.su-border-l{border-left-width:1px}
 .su-border-l-2{border-left-width:2px}
 .su-border-l-5{border-left-width:5px}
 .su-border-r{border-right-width:1px}
@@ -2994,8 +3031,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bg-black-30{--tw-bg-opacity:1;background-color:rgb(192 192 191 / var(--tw-bg-opacity))}
 .su-bg-black-40{--tw-bg-opacity:1;background-color:rgb(171 171 169 / var(--tw-bg-opacity))}
 .su-bg-black-true{--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
+.su-bg-black-true\/20{background-color:rgb(0 0 0 / 0.2)}
 .su-bg-black-true\/75{background-color:rgb(0 0 0 / 0.75)}
 .su-bg-black\/\[0\.33\]{background-color:rgb(46 45 41 / 0.33)}
+.su-bg-campaign-fog{--tw-bg-opacity:1;background-color:rgb(249 249 249 / var(--tw-bg-opacity))}
 .su-bg-digital-green-dark{--tw-bg-opacity:1;background-color:rgb(0 111 84 / var(--tw-bg-opacity))}
 .su-bg-digital-red{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
 .su-bg-digital-red-dark{--tw-bg-opacity:1;background-color:rgb(130 0 0 / var(--tw-bg-opacity))}
@@ -3019,6 +3058,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-via-black-true{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #000000 var(--tw-gradient-via-position), var(--tw-gradient-to)}
 .su-via-black-true\/10{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(0 0 0 / 0.1) var(--tw-gradient-via-position), var(--tw-gradient-to)}
 .su-via-digital-red-light{--tw-gradient-to:rgb(229 8 8 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #E50808 var(--tw-gradient-via-position), var(--tw-gradient-to)}
+.su-via-20\%{--tw-gradient-via-position:20%}
 .su-via-80\%{--tw-gradient-via-position:80%}
 .su-to-black-true{--tw-gradient-to:#000000 var(--tw-gradient-to-position)}
 .su-to-black-true\/60{--tw-gradient-to:rgb(0 0 0 / 0.6) var(--tw-gradient-to-position)}
@@ -3079,6 +3119,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-px-\[20px\]{padding-left:20px;padding-right:20px}
 .su-py-0{padding-top:0;padding-bottom:0}
 .su-py-10{padding-top:1rem;padding-bottom:1rem}
+.su-py-14{padding-top:1.4rem;padding-bottom:1.4rem}
 .su-py-15{padding-top:1.5rem;padding-bottom:1.5rem}
 .su-py-17{padding-top:1.7rem;padding-bottom:1.7rem}
 .su-py-20{padding-top:2rem;padding-bottom:2rem}
@@ -3153,6 +3194,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pt-20{padding-top:2rem}
 .su-pt-21{padding-top:2.1rem}
 .su-pt-27{padding-top:2.7rem}
+.su-pt-300{padding-top:30rem}
 .su-pt-32{padding-top:3.2rem}
 .su-pt-34{padding-top:3.4rem}
 .su-pt-36{padding-top:3.6rem}
@@ -3212,6 +3254,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-\[35px\]{font-size:35px}
 .su-text-\[39px\]{font-size:39px}
 .su-text-\[3rem\]{font-size:3rem}
+.su-text-\[4\.5rem\]{font-size:4.5rem}
 .su-text-\[4\.6rem\]{font-size:4.6rem}
 .su-text-\[4\.8rem\]{font-size:4.8rem}
 .su-text-\[40px\]{font-size:40px}
@@ -3292,6 +3335,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-black-60{--tw-text-opacity:1;color:rgb(118 118 116 / var(--tw-text-opacity))}
 .su-text-black-70{--tw-text-opacity:1;color:rgb(109 108 105 / var(--tw-text-opacity))}
 .su-text-black-90{--tw-text-opacity:1;color:rgb(67 66 62 / var(--tw-text-opacity))}
+.su-text-black-true{--tw-text-opacity:1;color:rgb(0 0 0 / var(--tw-text-opacity))}
 .su-text-dark-mode-red{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .su-text-digital-blue{--tw-text-opacity:1;color:rgb(0 108 184 / var(--tw-text-opacity))}
 .su-text-digital-blue-vivid{--tw-text-opacity:1;color:rgb(5 151 255 / var(--tw-text-opacity))}
@@ -3306,6 +3350,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-decoration-dark-mode-red{text-decoration-color:#EC0909}
 .su-decoration-2{text-decoration-thickness:2px}
 .su-decoration-\[3px\]{text-decoration-thickness:3px}
+.su-underline-offset-2{text-underline-offset:2px}
 .su-underline-offset-4{text-underline-offset:4px}
 .su-opacity-0{opacity:0}
 .su-opacity-100{opacity:1}
@@ -3339,6 +3384,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-will-change-transform{will-change:transform}
 .su-backface-hidden{backface-visibility:hidden}
 .su-break-words{word-break:break-word}
+.su-text-shadow-lg{text-shadow:0 8px 16px var(--tw-shadow-color)}
 .su-text-shadow-title{text-shadow:0px 0px 30px var(--tw-shadow-color), 0px 0px 30px var(--tw-shadow-color)}
 .\[perspective\:100rem\]{perspective:100rem}
 .\[taxonomyContentTypeId\:28201\]{taxonomy-content-type-id:28201}
@@ -4170,6 +4216,20 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .hocus\:su-no-underline:focus{text-decoration-line:none}
 .hocus\:su-decoration-white:focus{text-decoration-color:#fff}
 .hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(177\2c 4\2c 14\2c 1\)\]:focus{--tw-shadow:inset 0 0 0 3px rgba(177,4,14,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
+.hocus-visible\:su-scale-110:hover{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+@keyframes su-pulse{
+50%{opacity:.5}}
+.hocus-visible\:su-animate-pulse:hover{animation:su-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite}
+.hocus-visible\:su-text-white:hover{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+.hocus-visible\:su-underline:hover{text-decoration-line:underline}
+.hocus-visible\:su-decoration-white:hover{text-decoration-color:#fff}
+.hocus-visible\:su-scale-110:focus-visible{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+@keyframes su-pulse{
+50%{opacity:.5}}
+.hocus-visible\:su-animate-pulse:focus-visible{animation:su-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite}
+.hocus-visible\:su-text-white:focus-visible{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+.hocus-visible\:su-underline:focus-visible{text-decoration-line:underline}
+.hocus-visible\:su-decoration-white:focus-visible{text-decoration-color:#fff}
 .su-group:focus .group-hocus\:su--translate-y-01em{--tw-translate-y:-0.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus .group-hocus\:su--translate-y-02em{--tw-translate-y:-0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus .group-hocus\:su-translate-x-01em{--tw-translate-x:0.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -4194,6 +4254,14 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-group:hover .group-hocus\:su-text-digital-red{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .su-group:hover .group-hocus\:su-text-white{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .su-group:hover .group-hocus\:su-underline{text-decoration-line:underline}
+.su-group:focus-visible .group-hocus-visible\:su-scale-110{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+@keyframes su-pulse{
+50%{opacity:.5}}
+.su-group:focus-visible .group-hocus-visible\:su-animate-pulse{animation:su-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite}
+.su-group:hover .group-hocus-visible\:su-scale-110{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+@keyframes su-pulse{
+50%{opacity:.5}}
+.su-group:hover .group-hocus-visible\:su-animate-pulse{animation:su-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite}
 .su-group:focus-within .group-hocus-within\:su--translate-y-02em{--tw-translate-y:-0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus-within .group-hocus-within\:su-translate-x-02em{--tw-translate-x:0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-group:focus-within .group-hocus-within\:su-translate-x-03em{--tw-translate-x:0.3em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -4311,6 +4379,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 :is(.su-dark .dark\:hocus\:su-ring-1:focus){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
 :is(.su-dark .dark\:hocus\:su-ring-2:focus){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
 :is(.su-dark .dark\:hocus\:su-ring-white:focus){--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
+:is(.su-dark .dark\:hocus-visible\:su-text-white:hover){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:hocus-visible\:su-text-white:focus-visible){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 :is(.su-dark .su-group:focus .dark\:group-hocus\:su-text-dark-mode-red){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 :is(.su-dark .su-group:focus .dark\:group-hocus\:su-text-white){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 :is(.su-dark .su-group:hover .dark\:group-hocus\:su-text-dark-mode-red){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
@@ -4423,6 +4493,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-flex{display:flex}
 .md\:su-grid{display:grid}
 .md\:su-hidden{display:none}
+.md\:su-size-200{width:20rem;height:20rem}
 .md\:su-size-50{width:5rem;height:5rem}
 .md\:su-size-70{width:7rem;height:7rem}
 .md\:su-h-3{height:0.3rem}
@@ -4560,6 +4631,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pb-\[64px\]{padding-bottom:64px}
 .md\:su-pb-\[9px\]{padding-bottom:9px}
 .md\:su-pl-0{padding-left:0}
+.md\:su-pl-48{padding-left:4.8rem}
 .md\:su-pl-50{padding-left:5rem}
 .md\:su-pl-76{padding-left:7.6rem}
 .md\:su-pr-0{padding-right:0}
@@ -4574,6 +4646,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pt-\[159px\]{padding-top:159px}
 .md\:su-pt-\[167px\]{padding-top:167px}
 .md\:su-pt-\[21px\]{padding-top:21px}
+.md\:su-pt-\[40vw\]{padding-top:40vw}
 .md\:su-text-left{text-align:left}
 .md\:su-text-center{text-align:center}
 .md\:su-text-right{text-align:right}
@@ -4605,6 +4678,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-text-\[4rem\]{font-size:4rem}
 .md\:su-text-\[54px\]{font-size:54px}
 .md\:su-text-\[7\.2rem\]{font-size:7.2rem}
+.md\:su-text-\[7\.5rem\]{font-size:7.5rem}
 .md\:su-text-\[80px\]{font-size:80px}
 .md\:su-font-normal{font-weight:400}
 .md\:su-leading-\[1\.911rem\]{line-height:1.911rem}
@@ -4801,6 +4875,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-grid-cols-3{grid-template-columns:repeat(3, minmax(0, 1fr))}
 .lg\:su-grid-cols-4{grid-template-columns:repeat(4, minmax(0, 1fr))}
 .lg\:su-flex-row{flex-direction:row}
+.lg\:su-flex-row-reverse{flex-direction:row-reverse}
 .lg\:su-flex-col{flex-direction:column}
 .lg\:su-flex-wrap{flex-wrap:wrap}
 .lg\:su-flex-nowrap{flex-wrap:nowrap}
@@ -4878,6 +4953,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-pt-36{padding-top:3.6rem}
 .lg\:su-pt-90{padding-top:9rem}
 .lg\:su-pt-\[17\.5rem\]{padding-top:17.5rem}
+.lg\:su-pt-\[26vw\]{padding-top:26vw}
 .lg\:su-pt-\[27px\]{padding-top:27px}
 .lg\:su-text-left{text-align:left}
 .lg\:su-text-14{font-size:1.4rem}
@@ -5002,6 +5078,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\32xl\:su-left-48{left:4.8rem}
 .\32xl\:su--mt-58{margin-top:-5.8rem}
 .\32xl\:su-mt-171{margin-top:17.1rem}
+.\32xl\:su-size-300{width:30rem;height:30rem}
 .\32xl\:su-basis-\[30\%\]{flex-basis:30%}
 .\32xl\:su-basis-\[70\%\]{flex-basis:70%}
 .\32xl\:su-flex-row{flex-direction:row}
@@ -5010,7 +5087,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\32xl\:su-px-\[17rem\]{padding-left:17rem;padding-right:17rem}
 .\32xl\:su-px-\[6\.6rem\]{padding-left:6.6rem;padding-right:6.6rem}
 .\32xl\:su-py-140{padding-top:14rem;padding-bottom:14rem}
+.\32xl\:su-pl-200{padding-left:20rem}
 .\32xl\:su-pl-76{padding-left:7.6rem}
+.\32xl\:su-pt-400{padding-top:40rem}
 .\32xl\:su-text-\[2\.9rem\]{font-size:2.9rem}
 .\32xl\:su-text-\[3\.3rem\]{font-size:3.3rem}
 .\32xl\:su-text-\[4\.8rem\]{font-size:4.8rem}}

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -2983,9 +2983,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-from-white{--tw-gradient-from:#fff var(--tw-gradient-from-position);--tw-gradient-to:rgb(255 255 255 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-via-\[rgb\(255_255_255\/\.5\)_8\%\]{--tw-gradient-to:rgb(255 255 255 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(255 255 255/.5) 8% var(--tw-gradient-via-position), var(--tw-gradient-to)}
 .su-via-black-true{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #000000 var(--tw-gradient-via-position), var(--tw-gradient-to)}
-.su-via-black-true\/60{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(0 0 0 / 0.6) var(--tw-gradient-via-position), var(--tw-gradient-to)}
+.su-via-black-true\/10{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(0 0 0 / 0.1) var(--tw-gradient-via-position), var(--tw-gradient-to)}
 .su-via-digital-red-light{--tw-gradient-to:rgb(229 8 8 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #E50808 var(--tw-gradient-via-position), var(--tw-gradient-to)}
-.su-via-30\%{--tw-gradient-via-position:30%}
+.su-via-80\%{--tw-gradient-via-position:80%}
 .su-to-black-true{--tw-gradient-to:#000000 var(--tw-gradient-to-position)}
 .su-to-black-true\/60{--tw-gradient-to:rgb(0 0 0 / 0.6) var(--tw-gradient-to-position)}
 .su-to-cardinal-red-dark{--tw-gradient-to:#820000 var(--tw-gradient-to-position)}
@@ -4895,6 +4895,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\*\:lg\:su-size-100 > *{width:10rem;height:10rem}
 .\*\:lg\:su-h-\[100px\] > *{height:100px}
 .\*\:lg\:su-w-\[100px\] > *{width:100px}
+.\*\:lg\:su-max-w-none > *{max-width:none}
 .\*\:lg\:su-basis-1\/3 > *{flex-basis:33.333333%}
 .\*\:lg\:su-text-19 > *{font-size:1.9rem}
 .lg\:\*\:su-text-21 > *{font-size:2.1rem}

--- a/packages/headings/SidebarHeading.jsx
+++ b/packages/headings/SidebarHeading.jsx
@@ -31,37 +31,35 @@ export function SidebarHeading({
   icon,
   headingSize = "h2",
   color = "grey",
-  lightVariant = "light", // let components override light mode rendering of icons
-  darkVariant = "dark", // let components override dark mode rendering of icons
 }) {
   const iconMap = new Map();
   iconMap.set("announcement", {
-    light: <Announcement variant={lightVariant} />,
-    dark: <Announcement variant={darkVariant} />,
+    light: <Announcement variant="light" />,
+    dark: <Announcement variant="dark" />,
   });
   iconMap.set("eventscalendar", {
-    light: <EventsCalendar variant={lightVariant} />,
-    dark: <EventsCalendar variant={darkVariant} />,
+    light: <EventsCalendar variant="light" />,
+    dark: <EventsCalendar variant="dark" />,
   });
   iconMap.set("bullseyePointer", {
-    light: <BullseyePointer variant={lightVariant} />,
-    dark: <BullseyePointer variant={darkVariant} />,
+    light: <BullseyePointer variant="light" />,
+    dark: <BullseyePointer variant="dark" />,
   });
   iconMap.set("Featured reading", {
-    light: <FeaturedReading variant={lightVariant} />,
-    dark: <FeaturedReading variant={darkVariant} />,
+    light: <FeaturedReading variant="light" />,
+    dark: <FeaturedReading variant="dark" />,
   });
   iconMap.set("Featured audio", {
-    light: <FeaturedAudio variant={lightVariant} />,
-    dark: <FeaturedAudio variant={darkVariant} />,
+    light: <FeaturedAudio variant="light" />,
+    dark: <FeaturedAudio variant="dark" />,
   });
   iconMap.set("mediagallery", {
-    light: <MediaGallery variant={lightVariant} />,
-    dark: <MediaGallery variant={darkVariant} />,
+    light: <MediaGallery variant="light" />,
+    dark: <MediaGallery variant="dark" />,
   });
   iconMap.set("trendingup", {
-    light: <TrendingUp variant={lightVariant} />,
-    dark: <TrendingUp variant={darkVariant} />,
+    light: <TrendingUp variant="light" />,
+    dark: <TrendingUp variant="dark" />,
   });
 
   const colorClassMap = new Map();

--- a/packages/headings/SidebarHeading.jsx
+++ b/packages/headings/SidebarHeading.jsx
@@ -31,35 +31,37 @@ export function SidebarHeading({
   icon,
   headingSize = "h2",
   color = "grey",
+  lightVariant = "light", // let components override light mode rendering of icons
+  darkVariant = "dark", // let components override dark mode rendering of icons
 }) {
   const iconMap = new Map();
   iconMap.set("announcement", {
-    light: <Announcement variant="light" />,
-    dark: <Announcement variant="dark" />,
+    light: <Announcement variant={lightVariant} />,
+    dark: <Announcement variant={darkVariant} />,
   });
   iconMap.set("eventscalendar", {
-    light: <EventsCalendar variant="light" />,
-    dark: <EventsCalendar variant="dark" />,
+    light: <EventsCalendar variant={lightVariant} />,
+    dark: <EventsCalendar variant={darkVariant} />,
   });
   iconMap.set("bullseyePointer", {
-    light: <BullseyePointer variant="light" />,
-    dark: <BullseyePointer variant="dark" />,
+    light: <BullseyePointer variant={lightVariant} />,
+    dark: <BullseyePointer variant={darkVariant} />,
   });
   iconMap.set("Featured reading", {
-    light: <FeaturedReading variant="light" />,
-    dark: <FeaturedReading variant="dark" />,
+    light: <FeaturedReading variant={lightVariant} />,
+    dark: <FeaturedReading variant={darkVariant} />,
   });
   iconMap.set("Featured audio", {
-    light: <FeaturedAudio variant="light" />,
-    dark: <FeaturedAudio variant="dark" />,
+    light: <FeaturedAudio variant={lightVariant} />,
+    dark: <FeaturedAudio variant={darkVariant} />,
   });
   iconMap.set("mediagallery", {
-    light: <MediaGallery variant="light" />,
-    dark: <MediaGallery variant="dark" />,
+    light: <MediaGallery variant={lightVariant} />,
+    dark: <MediaGallery variant={darkVariant} />,
   });
   iconMap.set("trendingup", {
-    light: <TrendingUp variant="light" />,
-    dark: <TrendingUp variant="dark" />,
+    light: <TrendingUp variant={lightVariant} />,
+    dark: <TrendingUp variant={darkVariant} />,
   });
 
   const colorClassMap = new Map();


### PR DESCRIPTION
# READY FOR REVIEW

# Summary

- Update the dark mode hocus styles to match that of the light mode. We don’t need a color difference in font because the text is not on a black background.
  - I also updated the dark mode book / audio icon to match light mode - same reason.
- Update so that the entire transparent card area is clickable.

# Review By

9/5/2024

# Criticality

1 - Minor

# Review Tasks

1. Visit https://news.stanford.edu/developreport/stories/jb-test-page
1. Confirm that the entire Media Feature component is a link
1. Confirm the link :hocus style is the same in dark mode as it is in light mode
    1. @iamrentman @broleomo Is it ok that the entire summary is underlined on `:hocus`? That looks weird to me.
1. Confirm the book icon  is the same in dark mode as it is in light mode

# Associated Issues and/or People

- [UCP-3444](https://stanfordits.atlassian.net/browse/UCP-3444)


[UCP-3444]: https://stanfordits.atlassian.net/browse/UCP-3444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ