### PR TITLE
DS-1339 UCP-3959  | Max-widths for Updates page components

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@
 3. Verify...
 
 # Associated Issues and/or People
-- JIRA ticket(s) - STANFORD-000
+- JIRA ticket(s) - UCP-000
 - Other PRs
 - Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
 - Anyone who should be notified? (`@mention` them here)

--- a/components/button-row/preview.data.json
+++ b/components/button-row/preview.data.json
@@ -1,16 +1,16 @@
 {
     "buttons": [
         {
-            "buttonText": "Button 1",
+            "buttonText": "Button University Stanford Long Button Test",
             "internalUrl": "matrix-asset://api-identifier/28192"
         },
         {
-            "buttonText": "Button 2",
+            "buttonText": "Button University Stanford Long Button Test 2",
             "externalUrl": "https://google.com",
             "isNewWindow": true
         },
         {
-            "buttonText": "Button 3",
+            "buttonText": "Button",
             "externalUrl": "https://news.stanford.edu/2024/03/07/ai-makes-rendezvous-space/"
         }
     ]

--- a/components/multicolumn-info-section/Component.jsx
+++ b/components/multicolumn-info-section/Component.jsx
@@ -24,18 +24,18 @@ export default function MulticolumnInfoSection({
     <Container width="wide">
       <div
         className={cnb(
-          "su-grid su-grid-cols-6 su-grid-gap su-gap-y-0 md:su-grid-cols-12",
+          "su-grid lg:su-grid-cols-12 su-grid-gap su-gap-y-0 su-max-w-800 su-mx-auto lg:su-max-w-none",
           border &&
             "su-border-b su-rs-pb-5 su-border-b-black-30 dark:su-border-b-black"
         )}
       >
-        <h2 className="su-type-2 su-break-words su-col-span-full md:su-col-span-10 md:su-col-start-2 lg:su-col-span-8 xl:su-col-span-3">
+        <h2 className="su-type-2 su-break-words su-col-span-full lg:su-col-span-8 xl:su-col-span-3">
           {colOne.title}
         </h2>
         <XssSafeContent
           content={colTwo.infoText}
           className={cnb(
-            "su-col-span-full md:su-col-span-10 md:su-col-start-2 lg:su-col-span-8",
+            "su-col-span-full lg:su-col-span-8",
             callout
               ? "xl:su-col-span-6 xl:last:[&>*]:su-mb-0"
               : "xl:su-col-span-7 last:[&>*]:su-mb-0"
@@ -43,8 +43,8 @@ export default function MulticolumnInfoSection({
         />
         {callout && (
           <InfoBox
-            containerClassName="su-break-words su-col-span-full md:su-col-span-10 md:su-col-start-2 lg:su-col-span-4 lg:su-col-start-9 xl:su-col-span-3"
-            innerClassName="su-rs-p-0"
+            containerClassName="su-break-words su-col-span-full lg:su-col-span-4 lg:su-col-start-9 xl:su-col-span-3"
+            innerClassName="su-p-20 md:su-p-36 lg:su-px-20 lg:su-py-26"
             title={colThree.title}
             content={colThree.content}
             imageData={imageData}

--- a/components/multicolumn-info-section/manifest.json
+++ b/components/multicolumn-info-section/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "multicolumn-info-section",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "namespace": "stanford-components",
   "description": "The multicolumn info section displays a title in column 1, WYSIWYG content in column 2, and an optional text callout in column",
   "displayName": "Multicolumn Info Section",

--- a/components/two-column-text-callout/Component.jsx
+++ b/components/two-column-text-callout/Component.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cnb } from "cnbuilder";
 import InfoBox from "../../packages/info-box/InfoBox";
 import { Container } from "../../packages/grids/Container";
 
@@ -23,22 +24,30 @@ export default function TwoColumnTextCallout({
   showTopBorder = true,
   calloutsArray,
 }) {
+  const hasBothCallout = calloutsArray?.length === 2;
+
   return (
     <Container width="wide" marginTop={3} marginBottom={5}>
-      {showTopBorder && <hr className="su-border-black-30 su-rs-mb-3 su-h-1" />}
+      {showTopBorder && (
+        <hr className="su-border-black-30 dark:su-border-black su-rs-mb-3 su-h-1" />
+      )}
       {heading && (
         <h2 className="su-type-2 su-font-serif su-text-center su-w-auto su-rs-mb-2 su-text-black dark:su-text-white">
           {heading}
         </h2>
       )}
       <Container
-        paddingX
-        className="su-flex su-grid-gap su-flex-col lg:su-flex-row lg:su-items-stretch"
+        paddingX={false}
+        className={cnb(
+          "su-flex su-grid-gap su-flex-col md:su-max-w-800",
+          hasBothCallout &&
+            "lg:su-flex-row lg:su-items-stretch lg:*:su-basis-1/2 lg:su-max-w-[118.6rem] xl:su-px-50"
+        )}
       >
         {calloutsArray?.map((callout) => (
           <InfoBox
             key={callout.title}
-            innerClassName="su-p-20 md:su-p-36"
+            innerClassName="su-p-20 md:su-p-36 su-w-full"
             containerClassName="su-flex"
             title={callout.title}
             content={callout.content}

--- a/components/two-column-text-callout/manifest.json
+++ b/components/two-column-text-callout/manifest.json
@@ -1,13 +1,13 @@
 {
   "$schema": "http://localhost:3000/schemas/v1.json#",
   "name": "two-column-text-callout",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "namespace": "stanford-components",
   "description": "This component displays up to 2 text callouts boxes in a two-column layout.",
   "displayName": "Two Column Text Callout",
   "mainFunction": "main",
   "icon": {
-    "id": "fact_check",
+    "id": "campaign",
     "color": {
       "type": "enum",
       "value": "green"

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -97,9 +97,7 @@ svg {
  * This injects Tailwind's base styles and any base styles registered by
  * plugins.
  */
-*, ::before, ::after{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }
-::backdrop{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }
-/*! tailwindcss v3.4.13 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v3.4.1 | MIT License | https://tailwindcss.com */
 /*
 1. Prevent padding and border from affecting element width. (https://github.com/mozdevs/cssremedy/issues/4)
 2. Allow adding a border to an element by just adding a border-width. (https://github.com/tailwindcss/tailwindcss/pull/116)
@@ -249,7 +247,6 @@ textarea {
   font-size: 100%; /* 1 */
   font-weight: inherit; /* 1 */
   line-height: inherit; /* 1 */
-  letter-spacing: inherit; /* 1 */
   color: inherit; /* 1 */
   margin: 0; /* 2 */
   padding: 0; /* 3 */
@@ -266,9 +263,9 @@ select {
 2. Remove default button styles.
 */
 button,
-input:where([type='button']),
-input:where([type='reset']),
-input:where([type='submit']) {
+[type='button'],
+[type='reset'],
+[type='submit'] {
   -webkit-appearance: button; /* 1 */
   background-color: transparent; /* 2 */
   background-image: none; /* 2 */
@@ -532,6 +529,8 @@ h3{font-family:"Source Serif 4","Source Serif Pro",Georgia,Times,"Times New Roma
 h4{font-family:"Source Serif 4","Source Serif Pro",Georgia,Times,"Times New Roman",serif}
 h5{font-family:"Source Serif 4","Source Serif Pro",Georgia,Times,"Times New Roman",serif}
 h6{font-family:"Source Serif 4","Source Serif Pro",Georgia,Times,"Times New Roman",serif}
+*, ::before, ::after{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: }
+::backdrop{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:rgb(59 130 246 / 0.5);--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: }
 /**
  * This injects Tailwind's component classes and any component classes
  * registered by plugins.
@@ -543,32 +542,32 @@ h6{font-family:"Source Serif 4","Source Serif Pro",Georgia,Times,"Times New Roma
  */
 @tailwind utilities;
 table th{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-table th:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark table th){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 table caption{font-size:1.32em;letter-spacing:-0.012em;}
 @media (min-width: 768px){
 table caption{font-size:1.44em}}
 @media (min-width: 992px){
 table caption{font-size:1.56em}}
 table caption{font-family:"Source Serif 4", "Source Serif Pro", Georgia, Times, "Times New Roman", serif;font-weight:700;--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-table caption:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark table caption){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .su-bg-gradient,
 .su-bg-gradient-before:before,
 .su-bg-gradient-after:after{background-image:linear-gradient(to right, var(--tw-gradient-stops));--tw-gradient-from:#B1040E var(--tw-gradient-from-position);--tw-gradient-to:rgb(177 4 14 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#820000 var(--tw-gradient-to-position)}
-.su-bg-gradient:is(.su-dark *),
-.su-bg-gradient-before:is(.su-dark *):before,
-.su-bg-gradient-after:is(.su-dark *):after{--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+:is(.su-dark .su-bg-gradient),:is(.su-dark 
+.su-bg-gradient-before):before,:is(.su-dark 
+.su-bg-gradient-after):after{--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
 .su-bg-gradient-report{background-image:linear-gradient(to right, var(--tw-gradient-stops));--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
-.su-bg-gradient-report:is(.su-dark *){--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+:is(.su-dark .su-bg-gradient-report){--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
 .su-bg-gradient-b{background-image:linear-gradient(to bottom, var(--tw-gradient-stops));--tw-gradient-from:#B1040E var(--tw-gradient-from-position);--tw-gradient-to:rgb(177 4 14 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#820000 var(--tw-gradient-to-position)}
-.su-bg-gradient-b:is(.su-dark *){--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+:is(.su-dark .su-bg-gradient-b){--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
 .su-bg-gradient-light-red,
 .report-header__pref-toggle::before,
 .report-header__pref-toggle::after{background-image:linear-gradient(to bottom, var(--tw-gradient-stops));--tw-gradient-from:#E50808 var(--tw-gradient-from-position);--tw-gradient-to:rgb(229 8 8 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#820000 var(--tw-gradient-to-position)}
-.su-bg-gradient-light-red:is(.su-dark *),
-.report-header__pref-toggle:is(.su-dark *)::before,
-.report-header__pref-toggle:is(.su-dark *)::after{--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+:is(.su-dark .su-bg-gradient-light-red),:is(.su-dark 
+.report-header__pref-toggle)::before,:is(.su-dark 
+.report-header__pref-toggle)::after{--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
 .su-bg-gradient-light-red-h{background-image:linear-gradient(to right, var(--tw-gradient-stops));--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
-.su-bg-gradient-light-red-h:is(.su-dark *){--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+:is(.su-dark .su-bg-gradient-light-red-h){--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
 .su-bg-gradient-header-1 {
   background: linear-gradient(180deg, #1c4270 0%, rgba(0, 0, 0, 0) 53.4%),
     linear-gradient(180deg, rgba(0, 0, 0, 0) 64.92%, #fff 96.86%);
@@ -605,7 +604,7 @@ table caption:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--t
   background: linear-gradient(180deg, #fff 0.11%, rgba(0, 0, 0, 0) 50%);
 }
 .tt-menu::before{margin-bottom:1.9rem;font-size:2.6rem;font-weight:700;--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
-.tt-menu:is(.su-dark *)::before{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .tt-menu)::before{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .report-header .tt-menu {
   background-color: white;
 }
@@ -626,7 +625,7 @@ table caption:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--t
   box-shadow: 0 0 38px 0 rgba(46, 45, 41, 1);
 }
 .report-header input[type="search"]::placeholder{--tw-text-opacity:1;color:rgb(118 118 116 / var(--tw-text-opacity))}
-.report-header input[type="search"]:is(.su-dark *)::placeholder{--tw-text-opacity:1;color:rgb(213 213 212 / var(--tw-text-opacity))}
+:is(.su-dark .report-header input[type="search"])::placeholder{--tw-text-opacity:1;color:rgb(213 213 212 / var(--tw-text-opacity))}
 .report-header .tt-menu {
   box-shadow: 0 0 25px 0 rgba(0, 0, 0, 0.15);
 }
@@ -646,7 +645,7 @@ table caption:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--t
 } */
 .component-slider-cards .swiper-slide{position:relative;height:auto;transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .component-slider-cards .swiper-slide::before{position:absolute;top:0;left:-2rem;height:100%;width:0.1rem;content:var(--tw-content);--tw-bg-opacity:1;background-color:rgb(192 192 191 / var(--tw-bg-opacity))}
-.component-slider-cards .swiper-slide:is(.su-dark *)::before{content:var(--tw-content);--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
+:is(.su-dark .component-slider-cards .swiper-slide)::before{content:var(--tw-content);--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
 @media (min-width: 768px){
 .component-slider-cards .swiper-slide::before{content:var(--tw-content);left:-3.6rem}}
 @media (min-width: 992px){
@@ -700,7 +699,7 @@ table caption:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--t
   > *{opacity:0.4}
 .component-slider .component-slider-pagination{position:static;display:flex;gap:1rem;text-align:left}
 .component-slider .swiper-pagination-bullet{margin-left:0;margin-right:0;height:2rem;width:2rem;border-width:2px;border-style:solid;--tw-border-opacity:1;border-color:rgb(171 171 169 / var(--tw-border-opacity));background-color:transparent;opacity:1;transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
-.component-slider .swiper-pagination-bullet:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity))}
+:is(.su-dark .component-slider .swiper-pagination-bullet){--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity))}
 .component-slider.su-slider-dark .swiper-pagination-bullet{margin-left:0;margin-right:0;height:2rem;width:2rem;border-width:2px;border-style:solid;--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity));background-color:transparent;opacity:1;transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .component-slider
   .component-slider-vertical-videos
@@ -770,11 +769,11 @@ table caption:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--t
 .component-slider .swiper-pagination-bullet:hover{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
 .component-slider .swiper-pagination-bullet:focus-visible{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
 .component-slider .swiper-pagination-bullet:active{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
-.component-slider .swiper-pagination-bullet:hover:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
-.component-slider .swiper-pagination-bullet:focus-visible:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
-.component-slider .swiper-pagination-bullet:active:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .component-slider .swiper-pagination-bullet:hover){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .component-slider .swiper-pagination-bullet:focus-visible){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .component-slider .swiper-pagination-bullet:active){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
 .component-slider .swiper-pagination-bullet.swiper-pagination-bullet-active{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity))}
-.component-slider .swiper-pagination-bullet.swiper-pagination-bullet-active:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
+:is(.su-dark .component-slider .swiper-pagination-bullet.swiper-pagination-bullet-active){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
 .component-slider.su-slider-dark
   .swiper-pagination-bullet.swiper-pagination-bullet-active{--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
 .component-slider .component-slider-controls{display:flex;gap:2rem}
@@ -782,18 +781,18 @@ table caption:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--t
 .component-slider .component-slider-controls{gap:2.7rem}}
 .component-slider .swiper-pagination-lock .component-slider-btn,
 .component-slider .component-slider-btn svg{--tw-border-opacity:1;border-color:rgb(192 192 191 / var(--tw-border-opacity))}
-.component-slider .swiper-pagination-lock .component-slider-btn:is(.su-dark *),
-.component-slider .component-slider-btn svg:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity))}
+:is(.su-dark .component-slider .swiper-pagination-lock .component-slider-btn),:is(.su-dark 
+.component-slider .component-slider-btn svg){--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity))}
 .component-slider .component-slider-btn svg{margin-left:auto;margin-right:auto;fill:transparent;stroke:currentColor}
 .component-slider .component-slider-prev svg{--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .component-slider .component-slider-btn{position:relative;top:auto;bottom:0;height:3.7rem;min-width:3.7rem;max-width:3.7rem;border-radius:9999px;border-width:2px;--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity));transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .component-slider .component-slider-btn:hover{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .component-slider .component-slider-btn:focus-visible{--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.component-slider .component-slider-btn:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
-.component-slider .component-slider-btn:hover:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
-.component-slider .component-slider-btn:focus-visible:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
-.component-slider .component-slider-btn:hover:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.component-slider .component-slider-btn:focus:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .component-slider .component-slider-btn){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .component-slider .component-slider-btn:hover){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
+:is(.su-dark .component-slider .component-slider-btn:focus-visible){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
+:is(.su-dark .component-slider .component-slider-btn:hover){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .component-slider .component-slider-btn:focus){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .component-slider.su-slider-dark .component-slider-btn{position:relative;top:auto;bottom:0;height:37px;min-width:37px;max-width:37px;border-radius:9999px;border-width:2px;border-style:solid;--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity));transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .component-slider.su-slider-dark .component-slider-btn:hover{--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
 .component-slider.su-slider-dark .component-slider-btn:focus-visible{--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
@@ -1197,6 +1196,201 @@ div[data-component="footer-component"]{position:relative}
 .su-page-has-sidebar .su-page-sidebar{margin-left:0;margin-right:0;margin-left:auto;margin-right:8.33%;margin-top:0;margin-bottom:9.5rem;max-height:230rem;width:25%;max-width:29.8rem;flex-direction:column;gap:9.5rem;padding-left:0;padding-right:0}}
 .su-page-story-featured .su-upper-content,
 .su-page-story-featured [data-component="feature-story-hero"]{margin-top:0 !important}
+.su-page.su-page-story-featured [data-component="text-callout"] > div{width:100%;max-width:732px}
+@media (min-width: 768px){
+.su-page.su-page-story-featured [data-component="text-callout"] > div{width:84.75%}}
+/** 
+  * Updates Page scoped max-width for contents
+*/
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="text-callout"]
+  > div{width:100%;padding-left:2rem;padding-right:2rem}
+@media (min-width: 576px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="text-callout"]
+  > div{padding-left:3rem;padding-right:3rem}}
+@media (min-width: 768px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="text-callout"]
+  > div{max-width:90rem;padding-left:5rem;padding-right:5rem}}
+@media (min-width: 992px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="text-callout"]
+  > div{max-width:96rem;padding-left:8rem;padding-right:8rem}}
+@media (min-width: 1200px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="text-callout"]
+  > div{max-width:80rem;padding-left:0;padding-right:0}}
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="pullquote"]
+  > div{width:100%;padding-left:2rem;padding-right:2rem}
+@media (min-width: 576px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="pullquote"]
+  > div{padding-left:3rem;padding-right:3rem}}
+@media (min-width: 768px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="pullquote"]
+  > div{max-width:90rem;padding-left:5rem;padding-right:5rem}}
+@media (min-width: 992px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="pullquote"]
+  > div{max-width:96rem;padding-left:8rem;padding-right:8rem}}
+@media (min-width: 1200px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="pullquote"]
+  > div{max-width:80rem;padding-left:0;padding-right:0}}
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div{width:100%;padding-left:2rem;padding-right:2rem}
+@media (min-width: 576px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div{padding-left:3rem;padding-right:3rem}}
+@media (min-width: 768px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div{max-width:90rem;padding-left:5rem;padding-right:5rem}}
+@media (min-width: 992px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div{max-width:96rem;padding-left:8rem;padding-right:8rem}}
+@media (min-width: 1200px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div{max-width:80rem;padding-left:0;padding-right:0}}
+@media (min-width: 768px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div
+  > section
+  > div{max-width:none}}
+@media (min-width: 992px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div
+  > section
+  > div{max-width:none}}
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="button-row"]
+  > div{width:100%;padding-left:2rem;padding-right:2rem}
+@media (min-width: 576px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="button-row"]
+  > div{padding-left:3rem;padding-right:3rem}}
+@media (min-width: 768px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="button-row"]
+  > div{max-width:90rem;padding-left:5rem;padding-right:5rem}}
+@media (min-width: 992px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="button-row"]
+  > div{max-width:96rem;padding-left:8rem;padding-right:8rem}}
+@media (min-width: 1200px){
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="button-row"]
+  > div{max-width:80rem;padding-left:0;padding-right:0}}
+.su-page:not(
+  .su-page-has-sidebar,
+  .su-page-story-featured,
+  .su-page-has-sidebar--left
+)
+  .su-page-content
+  > *:not(
+    [data-component],
+    .container,
+    .su-lower-content,
+    .su-above-footer,
+    .su-upper-content
+  ){width:100%;max-width:90rem}
 /*
 * Containers
 */
@@ -1451,18 +1645,18 @@ div[data-component="footer-component"]{position:relative}
   + [data-component="multicolumn-listing"]
   .component-multicolumn-listing.has-no-title
   .su-component-container::before{display:block;height:1px;width:100%;--tw-bg-opacity:1;background-color:rgb(192 192 191 / var(--tw-bg-opacity))}
-[data-component="featured-content"]
+:is(.su-dark [data-component="featured-content"]
   + [data-component="multicolumn-listing"]
   .component-multicolumn-listing.has-no-title
-  .su-component-container:is(.su-dark *)::before,
+  .su-component-container)::before,:is(.su-dark 
 [data-component="combined-content-grid"]
   + [data-component="multicolumn-listing"]
   .component-multicolumn-listing.has-no-title
-  .su-component-container:is(.su-dark *)::before,
+  .su-component-container)::before,:is(.su-dark 
 [data-component="single-featured-content"]
   + [data-component="multicolumn-listing"]
   .component-multicolumn-listing.has-no-title
-  .su-component-container:is(.su-dark *)::before{--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
+  .su-component-container)::before{--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
 [data-component="featured-content"]
   + [data-component="multicolumn-listing"]
   .component-multicolumn-listing.has-title,
@@ -1884,18 +2078,18 @@ Subscribe to Stanford Report Marketo form styles
 .marketo-sr-subscribe-form.mktoForm input[type="text"]:focus,
 .marketo-sr-subscribe-form.mktoForm input[type="email"]:focus,
 .marketo-sr-subscribe-form.mktoForm textarea:focus{border-color:rgb(5 151 255 / var(--tw-border-opacity));--tw-border-opacity:1;border-bottom-color:rgb(0 108 184 / var(--tw-border-opacity))}
-.marketo-sr-subscribe-form.mktoForm input[type="text"]:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm input[type="email"]:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm textarea:is(.su-dark *){border-color:rgb(118 118 116 / var(--tw-border-opacity));--tw-border-opacity:1;border-bottom-color:rgb(192 192 191 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.marketo-sr-subscribe-form.mktoForm input[type="text"]:focus:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm input[type="email"]:focus:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm textarea:focus:is(.su-dark *){--tw-ring-color:rgb(5 151 255 / 0.6)}
-.marketo-sr-subscribe-form.mktoForm input[type="text"]:hover:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm input[type="email"]:hover:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm textarea:hover:is(.su-dark *){border-color:rgb(133 204 255 / 0.8);--tw-border-opacity:1;border-bottom-color:rgb(133 204 255 / var(--tw-border-opacity))}
-.marketo-sr-subscribe-form.mktoForm input[type="text"]:focus:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm input[type="email"]:focus:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm textarea:focus:is(.su-dark *){border-color:rgb(133 204 255 / 0.8);--tw-border-opacity:1;border-bottom-color:rgb(133 204 255 / var(--tw-border-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="text"]),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="email"]),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm textarea){border-color:rgb(118 118 116 / var(--tw-border-opacity));--tw-border-opacity:1;border-bottom-color:rgb(192 192 191 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="text"]:focus),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="email"]:focus),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm textarea:focus){--tw-ring-color:rgb(5 151 255 / 0.6)}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="text"]:hover),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="email"]:hover),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm textarea:hover){border-color:rgb(133 204 255 / 0.8);--tw-border-opacity:1;border-bottom-color:rgb(133 204 255 / var(--tw-border-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="text"]:focus),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="email"]:focus),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm textarea:focus){border-color:rgb(133 204 255 / 0.8);--tw-border-opacity:1;border-bottom-color:rgb(133 204 255 / var(--tw-border-opacity))}
 /* Checkbox styles */
 .marketo-sr-subscribe-form.mktoForm .mktoCheckboxList,
 .marketo-sr-subscribe-form.mktoForm .mktoRadioList{margin-top:2rem;display:grid;grid-template-columns:auto 1fr;column-gap:1.4rem;row-gap:2.4rem;padding:0}
@@ -1917,18 +2111,18 @@ Subscribe to Stanford Report Marketo form styles
 .marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus{--tw-border-opacity:1;border-color:rgb(0 108 184 / var(--tw-border-opacity));--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);--tw-ring-color:rgb(133 204 255 / 0.4)}
 .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus:checked,
 .marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus:checked{--tw-bg-opacity:1;background-color:rgb(0 84 143 / var(--tw-bg-opacity))}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm input[type="radio"]:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(192 192 191 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:checked:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm input[type="radio"]:checked:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 108 184 / var(--tw-bg-opacity))}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm input[type="radio"]:hover:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-ring-color:rgb(5 151 255 / 0.6)}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover:checked:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm input[type="radio"]:hover:checked:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(5 151 255 / var(--tw-bg-opacity))}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-ring-color:rgb(5 151 255 / 0.6)}
-.marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus:checked:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus:checked:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(5 151 255 / var(--tw-bg-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]){--tw-border-opacity:1;border-color:rgb(192 192 191 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:checked),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:checked){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 108 184 / var(--tw-bg-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:hover){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-ring-color:rgb(5 151 255 / 0.6)}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:hover:checked),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:hover:checked){--tw-bg-opacity:1;background-color:rgb(5 151 255 / var(--tw-bg-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus){--tw-border-opacity:1;border-color:rgb(133 204 255 / var(--tw-border-opacity));--tw-ring-color:rgb(5 151 255 / 0.6)}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm input[type="checkbox"]:focus:checked),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm input[type="radio"]:focus:checked){--tw-bg-opacity:1;background-color:rgb(5 151 255 / var(--tw-bg-opacity))}
 .marketo-sr-subscribe-form.mktoForm input[type="radio"]{border-radius:9999px}
 /* Marketo puts the asterisk before the label text(?) so
 // we use flexbox to switch the order and put the asterisk
@@ -1936,15 +2130,15 @@ Subscribe to Stanford Report Marketo form styles
 .marketo-sr-subscribe-form.mktoForm .mktoLabel{display:flex;flex-direction:row-reverse;justify-content:flex-end}
 /* Make required asterisk red and give it a little margin.*/
 .marketo-sr-subscribe-form.mktoForm .mktoAsterix{--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
-.marketo-sr-subscribe-form.mktoForm .mktoAsterix:is(.su-dark *){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm .mktoAsterix){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .marketo-sr-subscribe-form.mktoForm .mktoAsterix {
   margin-inline-start: 0.2rem;
 }
 /* Error messages */
 .marketo-sr-subscribe-form.mktoForm .mktoErrorMsg,
 .marketo-sr-subscribe-form.mktoForm .mktoErrorDetail{margin-top:0.8rem;font-size:1.6rem;--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
-.marketo-sr-subscribe-form.mktoForm .mktoErrorMsg:is(.su-dark *),
-.marketo-sr-subscribe-form.mktoForm .mktoErrorDetail:is(.su-dark *){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm .mktoErrorMsg),:is(.su-dark 
+.marketo-sr-subscribe-form.mktoForm .mktoErrorDetail){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 /* This shift the error message up so when it's displayed, so it doesn't cause the input field to shift position */
 .marketo-sr-subscribe-form.mktoForm .mktoError{margin-bottom:-2.6rem}
 /* Add more margin above the submit button at the bottom.*/
@@ -1960,8 +2154,8 @@ Subscribe to Stanford Report Marketo form styles
 .marketo-sr-subscribe-form.mktoForm .mktoButton{font-size:1.8rem;line-height:1.2;transition-property:color, background-color, border-color, text-decoration-color, fill, stroke;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .marketo-sr-subscribe-form.mktoForm .mktoButton:hover{text-decoration-line:underline}
 .marketo-sr-subscribe-form.mktoForm .mktoButton:focus{text-decoration-line:underline}
-.marketo-sr-subscribe-form.mktoForm .mktoButton:hover:is(.su-dark *){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
-.marketo-sr-subscribe-form.mktoForm .mktoButton:focus:is(.su-dark *){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm .mktoButton:hover){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
+:is(.su-dark .marketo-sr-subscribe-form.mktoForm .mktoButton:focus){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
 @media (min-width: 768px){
 .marketo-sr-subscribe-form.mktoForm .mktoButton{padding-left:3rem;padding-right:3rem;padding-top:1.2rem;padding-bottom:1.4rem;font-size:2rem}}
 /* Grid setup for page with left sidebar. Need to refactor all page layouts similar to this. */
@@ -2128,9 +2322,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-media-feature-title-link{text-decoration-line:none}
 .su-media-feature-title-link:hover{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity));text-decoration-line:underline}
 .su-media-feature-title-link:focus{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity));text-decoration-line:underline}
-.su-media-feature-title-link:is(.su-dark *){--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-.su-media-feature-title-link:hover:is(.su-dark *){--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
-.su-media-feature-title-link:focus:is(.su-dark *){--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
+:is(.su-dark .su-media-feature-title-link){--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
+:is(.su-dark .su-media-feature-title-link:hover){--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
+:is(.su-dark .su-media-feature-title-link:focus){--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 @media (min-width: 992px){
 [data-component="media-carousel"] .su-component-container .component-slider{margin-left:auto;margin-right:auto}}
 [data-component="media-carousel"] .swiper-slide-visible .su-media-card-thumb{transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
@@ -2211,18 +2405,18 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
   background-color: currentColor}
 .su-bg-gradient-reverse,
 .su-bg-gradient-before-reverse:before{background-image:linear-gradient(to left, var(--tw-gradient-stops));--tw-gradient-from:#B1040E var(--tw-gradient-from-position);--tw-gradient-to:rgb(177 4 14 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#B1040E var(--tw-gradient-to-position)}
-.su-bg-gradient-reverse:is(.su-dark *),
-.su-bg-gradient-before-reverse:is(.su-dark *):before{--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#279989 var(--tw-gradient-to-position)}
+:is(.su-dark .su-bg-gradient-reverse),:is(.su-dark 
+.su-bg-gradient-before-reverse):before{--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#279989 var(--tw-gradient-to-position)}
 @media (min-width: 768px){
 .su-bg-gradient-reverse,
 .su-bg-gradient-before-reverse:before{background-image:linear-gradient(to left, var(--tw-gradient-stops));--tw-gradient-from:#B1040E var(--tw-gradient-from-position);--tw-gradient-to:rgb(177 4 14 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:rgb(229 8 8 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #E50808 var(--tw-gradient-via-position), var(--tw-gradient-to);--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
-.su-bg-gradient-reverse:is(.su-dark *),
-.su-bg-gradient-before-reverse:is(.su-dark *):before{--tw-gradient-from:#8F993E var(--tw-gradient-from-position);--tw-gradient-to:rgb(143 153 62 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#279989 var(--tw-gradient-to-position)}}
+:is(.su-dark .su-bg-gradient-reverse),:is(.su-dark 
+.su-bg-gradient-before-reverse):before{--tw-gradient-from:#8F993E var(--tw-gradient-from-position);--tw-gradient-to:rgb(143 153 62 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#279989 var(--tw-gradient-to-position)}}
 .su-bg-gradient-after-reverse:after{background-image:linear-gradient(to top, var(--tw-gradient-stops));--tw-gradient-from:#E50808 var(--tw-gradient-from-position);--tw-gradient-to:rgb(229 8 8 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#B1040E var(--tw-gradient-to-position)}
-.su-bg-gradient-after-reverse:is(.su-dark *):after{--tw-gradient-from:#8F993E var(--tw-gradient-from-position);--tw-gradient-to:rgb(143 153 62 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#279989 var(--tw-gradient-to-position)}
+:is(.su-dark .su-bg-gradient-after-reverse):after{--tw-gradient-from:#8F993E var(--tw-gradient-from-position);--tw-gradient-to:rgb(143 153 62 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#279989 var(--tw-gradient-to-position)}
 @media (min-width: 768px){
 .su-bg-gradient-after-reverse:after{background-image:linear-gradient(to bottom, var(--tw-gradient-stops));--tw-gradient-from:#B1040E var(--tw-gradient-from-position);--tw-gradient-to:rgb(177 4 14 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
-.su-bg-gradient-after-reverse:is(.su-dark *):after{--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}}
+:is(.su-dark .su-bg-gradient-after-reverse):after{--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}}
 .su-horizontal-image-first {
   grid-column: 1;
   grid-row: 1 / span 1;
@@ -2266,14 +2460,20 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
   transform: translateY(90px);
 }
 .su-bg-gradient-light-red-h-reverse{background-image:linear-gradient(to left, var(--tw-gradient-stops));--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
-.su-bg-gradient-light-red-h-reverse:is(.su-dark *){background-image:linear-gradient(to top left, var(--tw-gradient-stops));--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:rgb(39 153 137 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #279989 var(--tw-gradient-via-position), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+:is(.su-dark .su-bg-gradient-light-red-h-reverse){background-image:linear-gradient(to top left, var(--tw-gradient-stops));--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:rgb(39 153 137 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #279989 var(--tw-gradient-via-position), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+.su-aspect-h-16{--tw-aspect-h:16}
 .su-aspect-h-2{--tw-aspect-h:2}
+.su-aspect-h-9{--tw-aspect-h:9}
 .su-aspect-w-1{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:1}
 .su-aspect-w-1 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
+.su-aspect-w-16{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:16}
+.su-aspect-w-16 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
 .su-aspect-w-2{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:2}
 .su-aspect-w-2 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
 .su-aspect-w-3{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:3}
 .su-aspect-w-3 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
+.su-aspect-w-9{position:relative;padding-bottom:calc(var(--tw-aspect-h) / var(--tw-aspect-w) * 100%);--tw-aspect-w:9}
+.su-aspect-w-9 > *{position:absolute;height:100%;width:100%;top:0;right:0;bottom:0;left:0}
 .su-button{font-family:"Source Sans 3", "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;cursor:pointer;display:inline-block;border:none;font-weight:400;line-height:1;text-align:center;text-decoration:none;width:auto;transition:background-color 0.25s ease-in-out, color 0.25s ease-in-out;padding:1rem 2rem;background-color:#B1040E;color:#fff;}
 .su-button:active, .su-button:hover, .su-button:focus{text-decoration:underline}
 .su-button:hover, .su-button:focus{background-color:#2E2D29;color:#fff}
@@ -2342,6 +2542,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-py-1{padding-top:2.6rem;padding-bottom:2.6rem}}
 @media (min-width: 1500px){
 .su-rs-py-1{padding-top:2.7rem;padding-bottom:2.7rem}}
+.su-rs-p-2{padding:3rem;}
+@media (min-width: 768px){
+.su-rs-p-2{padding:3.6rem}}
+@media (min-width: 1500px){
+.su-rs-p-2{padding:3.8rem}}
 .su-rs-mt-2{margin-top:3rem;}
 @media (min-width: 768px){
 .su-rs-mt-2{margin-top:3.6rem}}
@@ -2377,6 +2582,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mt-3{margin-top:4.5rem}}
 @media (min-width: 1500px){
 .su-rs-mt-3{margin-top:4.8rem}}
+.su-rs-pt-3{padding-top:3.2rem;}
+@media (min-width: 768px){
+.su-rs-pt-3{padding-top:4.5rem}}
+@media (min-width: 1500px){
+.su-rs-pt-3{padding-top:4.8rem}}
 .su-rs-mb-3{margin-bottom:3.2rem;}
 @media (min-width: 768px){
 .su-rs-mb-3{margin-bottom:4.5rem}}
@@ -2387,6 +2597,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-py-3{padding-top:4.5rem;padding-bottom:4.5rem}}
 @media (min-width: 1500px){
 .su-rs-py-3{padding-top:4.8rem;padding-bottom:4.8rem}}
+.su-rs-px-3{padding-left:3.2rem;padding-right:3.2rem;}
+@media (min-width: 768px){
+.su-rs-px-3{padding-left:4.5rem;padding-right:4.5rem}}
+@media (min-width: 1500px){
+.su-rs-px-3{padding-left:4.8rem;padding-right:4.8rem}}
 .su-rs-mt-4{margin-top:3.4rem;}
 @media (min-width: 768px){
 .su-rs-mt-4{margin-top:5.8rem}}
@@ -2552,6 +2767,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mt-neg1{margin-top:1.2rem}}
 @media (min-width: 1500px){
 .su-rs-mt-neg1{margin-top:1.3rem}}
+.su-type-6{font-size:2.31em;letter-spacing:-0.020em;}
+@media (min-width: 768px){
+.su-type-6{font-size:2.99em}}
+@media (min-width: 992px){
+.su-type-6{font-size:3.81em}}
 .su-type-5{font-size:2.01em;letter-spacing:-0.018em;}
 @media (min-width: 768px){
 .su-type-5{font-size:2.49em}}
@@ -2615,21 +2835,28 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-relative{position:relative}
 .su-sticky{position:sticky}
 .su-inset-0{inset:0}
+.su--bottom-1{bottom:-0.1rem}
 .su--left-80{left:-8rem}
 .su-bottom-0{bottom:0}
 .su-bottom-100{bottom:10rem}
+.su-bottom-120{bottom:12rem}
 .su-bottom-13{bottom:1.3rem}
 .su-bottom-20{bottom:2rem}
+.su-bottom-27{bottom:2.7rem}
 .su-bottom-34{bottom:3.4rem}
+.su-bottom-38{bottom:3.8rem}
 .su-bottom-4{bottom:0.4rem}
+.su-bottom-80{bottom:8rem}
 .su-bottom-\[-100px\]{bottom:-100px}
 .su-left-0{left:0}
 .su-left-1{left:0.1rem}
 .su-left-1\/2{left:50%}
 .su-left-13{left:1.3rem}
 .su-left-20{left:2rem}
+.su-left-27{left:2.7rem}
 .su-left-3{left:0.3rem}
 .su-left-32{left:3.2rem}
+.su-left-38{left:3.8rem}
 .su-left-8{left:0.8rem}
 .su-left-9{left:0.9rem}
 .su-left-\[50\%\]{left:50%}
@@ -2639,8 +2866,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-right-10{right:1rem}
 .su-right-20{right:2rem}
 .su-right-38{right:3.8rem}
+.su-right-48{right:4.8rem}
 .su-right-60{right:6rem}
 .su-right-70{right:7rem}
+.su-right-9{right:0.9rem}
 .su-top-0{top:0}
 .su-top-1{top:0.1rem}
 .su-top-1\/2{top:50%}
@@ -2651,6 +2880,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-top-43{top:4.3rem}
 .su-top-5{top:0.5rem}
 .su-top-7{top:0.7rem}
+.su-top-72{top:7.2rem}
 .su-top-9{top:0.9rem}
 .su-top-\[-1\%\]{top:-1%}
 .su-top-\[1\.75em\]{top:1.75em}
@@ -2674,39 +2904,71 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-order-4{order:4}
 .su-order-first{order:-9999}
 .su-col-span-1{grid-column:span 1 / span 1}
+.su-col-span-10{grid-column:span 10 / span 10}
+.su-col-span-12{grid-column:span 12 / span 12}
+.su-col-span-3{grid-column:span 3 / span 3}
+.su-col-span-4{grid-column:span 4 / span 4}
 .su-col-span-5{grid-column:span 5 / span 5}
 .su-col-span-6{grid-column:span 6 / span 6}
+.su-col-span-7{grid-column:span 7 / span 7}
+.su-col-span-8{grid-column:span 8 / span 8}
 .su-col-span-full{grid-column:1 / -1}
 .su-col-start-1{grid-column-start:1}
 .su-col-start-2{grid-column-start:2}
+.su-col-start-3{grid-column-start:3}
+.su-col-start-4{grid-column-start:4}
+.su-col-start-5{grid-column-start:5}
+.su-col-start-6{grid-column-start:6}
+.su-col-start-7{grid-column-start:7}
+.su-col-start-8{grid-column-start:8}
+.su-col-start-9{grid-column-start:9}
 .su-float-left{float:left}
 .\!su-m-0{margin:0 !important}
 .su-m-0{margin:0}
 .\!su-mx-0{margin-left:0 !important;margin-right:0 !important}
 .su--mx-18{margin-left:-1.8rem;margin-right:-1.8rem}
 .su-mx-0{margin-left:0;margin-right:0}
+.su-mx-50{margin-left:5rem;margin-right:5rem}
 .su-mx-\[-20px\]{margin-left:-20px;margin-right:-20px}
 .su-mx-auto{margin-left:auto;margin-right:auto}
 .su-my-0{margin-top:0;margin-bottom:0}
 .su-my-20{margin-top:2rem;margin-bottom:2rem}
+.su-my-27{margin-top:2.7rem;margin-bottom:2.7rem}
 .su-my-38{margin-top:3.8rem;margin-bottom:3.8rem}
+.su-my-72{margin-top:7.2rem;margin-bottom:7.2rem}
+.su-my-76{margin-top:7.6rem;margin-bottom:7.6rem}
 .su-my-auto{margin-top:auto;margin-bottom:auto}
 .\!su-mb-0{margin-bottom:0 !important}
+.-su-mt-500{margin-top:-50rem}
+.-su-mt-800{margin-top:-80rem}
 .-su-mt-\[16\.2rem\]{margin-top:-16.2rem}
 .su--mb-3{margin-bottom:-0.3rem}
+.su--ml-1em{margin-left:-1em}
 .su--ml-3{margin-left:-0.3rem}
 .su--ml-44{margin-left:-4.4rem}
 .su--ml-5{margin-left:-0.5rem}
+.su--mt-14{margin-top:-1.4rem}
+.su--mt-2{margin-top:-0.2rem}
+.su--mt-20{margin-top:-2rem}
 .su--mt-24{margin-top:-2.4rem}
 .su--mt-50{margin-top:-5rem}
 .su-mb-0{margin-bottom:0}
+.su-mb-01em{margin-bottom:0.1em}
 .su-mb-02em{margin-bottom:0.2em}
+.su-mb-03em{margin-bottom:0.3em}
+.su-mb-06em{margin-bottom:0.6em}
 .su-mb-10{margin-bottom:1rem}
 .su-mb-11{margin-bottom:1.1rem}
 .su-mb-12{margin-bottom:1.2rem}
+.su-mb-13{margin-bottom:1.3rem}
+.su-mb-14{margin-bottom:1.4rem}
 .su-mb-15{margin-bottom:1.5rem}
+.su-mb-18{margin-bottom:1.8rem}
 .su-mb-19{margin-bottom:1.9rem}
+.su-mb-1em{margin-bottom:1em}
 .su-mb-20{margin-bottom:2rem}
+.su-mb-25{margin-bottom:2.5rem}
+.su-mb-26{margin-bottom:2.6rem}
 .su-mb-27{margin-bottom:2.7rem}
 .su-mb-3{margin-bottom:0.3rem}
 .su-mb-30{margin-bottom:3rem}
@@ -2714,9 +2976,14 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mb-36{margin-bottom:3.6rem}
 .su-mb-37{margin-bottom:3.7rem}
 .su-mb-38{margin-bottom:3.8rem}
+.su-mb-41{margin-bottom:4.1rem}
 .su-mb-45{margin-bottom:4.5rem}
+.su-mb-450{margin-bottom:45rem}
 .su-mb-5{margin-bottom:0.5rem}
+.su-mb-58{margin-bottom:5.8rem}
 .su-mb-6{margin-bottom:0.6rem}
+.su-mb-60{margin-bottom:6rem}
+.su-mb-61{margin-bottom:6.1rem}
 .su-mb-8{margin-bottom:0.8rem}
 .su-mb-9{margin-bottom:0.9rem}
 .su-mb-\[-\.5em\]{margin-bottom:-.5em}
@@ -2727,41 +2994,64 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mb-auto{margin-bottom:auto}
 .su-ml-0{margin-left:0}
 .su-ml-04em{margin-left:0.4em}
+.su-ml-05em{margin-left:0.5em}
 .su-ml-1{margin-left:0.1rem}
+.su-ml-10{margin-left:1rem}
 .su-ml-13{margin-left:1.3rem}
+.su-ml-19{margin-left:1.9rem}
+.su-ml-26{margin-left:2.6rem}
+.su-ml-38{margin-left:3.8rem}
 .su-ml-4{margin-left:0.4rem}
 .su-ml-5{margin-left:0.5rem}
 .su-ml-8{margin-left:0.8rem}
+.su-ml-80{margin-left:8rem}
 .su-ml-\[-\.5rem\]{margin-left:-.5rem}
 .su-ml-\[-3px\]{margin-left:-3px}
 .su-ml-auto{margin-left:auto}
 .su-mr-0{margin-right:0}
 .su-mr-02em{margin-right:0.2em}
+.su-mr-13{margin-right:1.3rem}
 .su-mr-19{margin-right:1.9rem}
 .su-mr-2{margin-right:0.2rem}
+.su-mr-25{margin-right:2.5rem}
+.su-mr-36{margin-right:3.6rem}
 .su-mr-4{margin-right:0.4rem}
 .su-mr-44{margin-right:4.4rem}
 .su-mr-6{margin-right:0.6rem}
 .su-mr-8{margin-right:0.8rem}
 .su-mr-auto{margin-right:auto}
 .su-mt-0{margin-top:0}
+.su-mt-10{margin-top:1rem}
 .su-mt-11{margin-top:1.1rem}
+.su-mt-110{margin-top:11rem}
 .su-mt-12{margin-top:1.2rem}
 .su-mt-14{margin-top:1.4rem}
 .su-mt-15{margin-top:1.5rem}
+.su-mt-160{margin-top:16rem}
 .su-mt-17{margin-top:1.7rem}
 .su-mt-18{margin-top:1.8rem}
 .su-mt-19{margin-top:1.9rem}
 .su-mt-2{margin-top:0.2rem}
+.su-mt-20{margin-top:2rem}
+.su-mt-200{margin-top:20rem}
+.su-mt-26{margin-top:2.6rem}
 .su-mt-27{margin-top:2.7rem}
+.su-mt-29{margin-top:2.9rem}
+.su-mt-3{margin-top:0.3rem}
 .su-mt-30{margin-top:3rem}
+.su-mt-31{margin-top:3.1em}
 .su-mt-32{margin-top:3.2rem}
 .su-mt-34{margin-top:3.4rem}
+.su-mt-36{margin-top:3.6rem}
 .su-mt-38{margin-top:3.8rem}
 .su-mt-4{margin-top:0.4rem}
 .su-mt-45{margin-top:4.5rem}
+.su-mt-48{margin-top:4.8rem}
 .su-mt-50{margin-top:5rem}
+.su-mt-58{margin-top:5.8rem}
+.su-mt-6{margin-top:0.6rem}
 .su-mt-61{margin-top:6.1rem}
+.su-mt-72{margin-top:7.2rem}
 .su-mt-8{margin-top:0.8rem}
 .su-mt-9{margin-top:0.9rem}
 .su-mt-\[-63px\]{margin-top:-63px}
@@ -2772,6 +3062,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-mt-\[3\.2rem\]{margin-top:3.2rem}
 .su-mt-\[71px\]{margin-top:71px}
 .su-mt-auto{margin-top:auto}
+.su-box-border{box-sizing:border-box}
 .su-block{display:block}
 .su-inline-block{display:inline-block}
 .su-inline{display:inline}
@@ -2786,32 +3077,49 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-size-13{width:1.3rem;height:1.3rem}
 .su-size-14{width:1.4rem;height:1.4rem}
 .su-size-150{width:15rem;height:15rem}
+.su-size-16{width:1.6rem;height:1.6rem}
 .su-size-160{width:16rem;height:16rem}
 .su-size-18{width:1.8rem;height:1.8rem}
+.su-size-1em{width:1em;height:1em}
 .su-size-20{width:2rem;height:2rem}
 .su-size-200{width:20rem;height:20rem}
 .su-size-24{width:2.4rem;height:2.4rem}
 .su-size-30{width:3rem;height:3rem}
 .su-size-32{width:3.2rem;height:3.2rem}
+.su-size-36{width:3.6rem;height:3.6rem}
 .su-size-40{width:4rem;height:4rem}
 .su-size-50{width:5rem;height:5rem}
+.su-size-70{width:7rem;height:7rem}
 .su-size-full{width:100%;height:100%}
 .su-h-0{height:0}
 .su-h-1{height:0.1rem}
 .su-h-100{height:10rem}
+.su-h-1000{height:100rem}
+.su-h-130{height:13rem}
+.su-h-150{height:15rem}
+.su-h-160{height:16rem}
 .su-h-2{height:0.2rem}
+.su-h-20{height:2rem}
+.su-h-200{height:20rem}
 .su-h-21{height:2.1rem}
 .su-h-28{height:2.8rem}
 .su-h-3{height:0.3rem}
 .su-h-32{height:3.2rem}
 .su-h-35{height:3.5rem}
 .su-h-4{height:0.4rem}
+.su-h-40{height:4rem}
+.su-h-42{height:4.2rem}
+.su-h-43{height:4.3rem}
 .su-h-44{height:4.4rem}
+.su-h-45{height:4.5rem}
 .su-h-48{height:4.8rem}
 .su-h-50{height:5rem}
+.su-h-500{height:50rem}
 .su-h-6{height:0.6rem}
+.su-h-60{height:6rem}
 .su-h-72{height:7.2rem}
 .su-h-75{height:7.5rem}
+.su-h-9{height:0.9rem}
 .su-h-90{height:9rem}
 .su-h-\[101\%\]{height:101%}
 .su-h-\[165px\]{height:165px}
@@ -2845,7 +3153,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-max-h-1000{max-height:100rem}
 .su-max-h-70{max-height:7rem}
 .su-max-h-\[103px\]{max-height:103px}
-.su-min-h-\[5\.6rem\]{min-height:5.6rem}
 .su-min-h-\[56px\]{min-height:56px}
 .su-min-h-full{min-height:100%}
 .\!su-w-full{width:100% !important}
@@ -2861,14 +3168,21 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-w-28{width:2.8rem}
 .su-w-3{width:0.3rem}
 .su-w-3\/4{width:75%}
+.su-w-30{width:3rem}
 .su-w-32{width:3.2rem}
+.su-w-36{width:3.6rem}
 .su-w-4{width:0.4rem}
+.su-w-40{width:4rem}
+.su-w-41{width:4.1rem}
+.su-w-42{width:4.2rem}
 .su-w-44{width:4.4rem}
 .su-w-5{width:0.5rem}
 .su-w-5\/6{width:83.333333%}
 .su-w-50{width:5rem}
 .su-w-58{width:5.8rem}
+.su-w-60{width:6rem}
 .su-w-70{width:7rem}
+.su-w-85{width:8.5rem}
 .su-w-\[1\.2em\]{width:1.2em}
 .su-w-\[1\.838rem\]{width:1.838rem}
 .su-w-\[10\%\]{width:10%}
@@ -2933,11 +3247,18 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-grow{flex-grow:1}
 .su-basis-1{flex-basis:0.1rem}
 .su-basis-4{flex-basis:0.4rem}
+.su-basis-auto{flex-basis:auto}
 .-su-translate-x-1{--tw-translate-x:-0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .-su-translate-x-1\/2{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .-su-translate-y-1{--tw-translate-y:-0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .-su-translate-y-1\/2{--tw-translate-y:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su--translate-y-01em{--tw-translate-y:-0.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su--translate-y-02em{--tw-translate-y:-0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-0{--tw-translate-x:0;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-translate-x-01em{--tw-translate-x:0.1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-translate-x-02em{--tw-translate-x:0.2em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-translate-x-03em{--tw-translate-x:0.3em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-translate-x-1em{--tw-translate-x:1em;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-x-\[-50\%\]{--tw-translate-x:-50%;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-0{--tw-translate-y:0;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-translate-y-1{--tw-translate-y:0.1rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
@@ -2947,12 +3268,15 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rotate-45{--tw-rotate:45deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-rotate-90{--tw-rotate:90deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-rotate-\[-90deg\]{--tw-rotate:-90deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+.su-scale-110{--tw-scale-x:1.1;--tw-scale-y:1.1;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .su-cursor-pointer{cursor:pointer}
 .su-list-none{list-style-type:none}
 .su-grid-cols-1{grid-template-columns:repeat(1, minmax(0, 1fr))}
 .su-grid-cols-10{grid-template-columns:repeat(10, minmax(0, 1fr))}
 .su-grid-cols-12{grid-template-columns:repeat(12, minmax(0, 1fr))}
 .su-grid-cols-2{grid-template-columns:repeat(2, minmax(0, 1fr))}
+.su-grid-cols-3{grid-template-columns:repeat(3, minmax(0, 1fr))}
+.su-grid-cols-4{grid-template-columns:repeat(4, minmax(0, 1fr))}
 .su-grid-cols-6{grid-template-columns:repeat(6, minmax(0, 1fr))}
 .su-grid-rows-2{grid-template-rows:repeat(2, minmax(0, 1fr))}
 .su-flex-row{flex-direction:row}
@@ -2973,6 +3297,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-justify-center{justify-content:center}
 .su-justify-between{justify-content:space-between}
 .su-justify-evenly{justify-content:space-evenly}
+.su-gap-0{gap:0}
 .su-gap-02em{gap:0.2em}
 .su-gap-10{gap:1rem}
 .su-gap-11{gap:1.1rem}
@@ -2983,22 +3308,29 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-19{gap:1.9rem}
 .su-gap-2{gap:0.2rem}
 .su-gap-20{gap:2rem}
+.su-gap-22{gap:2.2rem}
+.su-gap-25{gap:2.5rem}
 .su-gap-26{gap:2.6rem}
 .su-gap-27{gap:2.7rem}
+.su-gap-29{gap:2.9rem}
+.su-gap-2xl{gap:48px}
 .su-gap-3{gap:0.3rem}
 .su-gap-30{gap:3rem}
 .su-gap-32{gap:3.2rem}
 .su-gap-34{gap:3.4rem}
 .su-gap-36{gap:3.6rem}
+.su-gap-38{gap:3.8rem}
 .su-gap-40{gap:4rem}
 .su-gap-42{gap:4.2rem}
 .su-gap-44{gap:4.4rem}
+.su-gap-45{gap:4.5rem}
 .su-gap-48{gap:4.8rem}
 .su-gap-5{gap:0.5rem}
 .su-gap-6{gap:0.6rem}
 .su-gap-60{gap:6rem}
 .su-gap-61{gap:6.1rem}
 .su-gap-7{gap:0.7rem}
+.su-gap-72{gap:7.2rem}
 .su-gap-8{gap:0.8rem}
 .su-gap-80{gap:8rem}
 .su-gap-9{gap:0.9rem}
@@ -3013,12 +3345,18 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-gap-x-16{column-gap:1.6rem}
 .su-gap-x-18{column-gap:1.8rem}
 .su-gap-x-20{column-gap:2rem}
+.su-gap-x-24{column-gap:2.4rem}
+.su-gap-x-27{column-gap:2.7rem}
+.su-gap-x-29{column-gap:2.9rem}
+.su-gap-x-31{column-gap:3.1em}
+.su-gap-x-40{column-gap:4rem}
 .su-gap-x-\[0\.691rem\]{column-gap:0.691rem}
 .su-gap-y-0{row-gap:0}
 .su-gap-y-11{row-gap:1.1rem}
 .su-gap-y-12{row-gap:1.2rem}
 .su-gap-y-45{row-gap:4.5rem}
 .su-gap-y-6{row-gap:0.6rem}
+.su-gap-y-70{row-gap:7rem}
 .su-gap-y-8{row-gap:0.8rem}
 .su-gap-y-\[0\.572rem\]{row-gap:0.572rem}
 .su-divide-x-2 > :not([hidden]) ~ :not([hidden]){--tw-divide-x-reverse:0;border-right-width:calc(2px * var(--tw-divide-x-reverse));border-left-width:calc(2px * calc(1 - var(--tw-divide-x-reverse)))}
@@ -3026,6 +3364,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-divide-y-2 > :not([hidden]) ~ :not([hidden]){--tw-divide-y-reverse:0;border-top-width:calc(2px * calc(1 - var(--tw-divide-y-reverse)));border-bottom-width:calc(2px * var(--tw-divide-y-reverse))}
 .su-divide-black-30 > :not([hidden]) ~ :not([hidden]){--tw-divide-opacity:1;border-color:rgb(192 192 191 / var(--tw-divide-opacity))}
 .su-divide-black-60 > :not([hidden]) ~ :not([hidden]){--tw-divide-opacity:1;border-color:rgb(118 118 116 / var(--tw-divide-opacity))}
+.su-self-start{align-self:flex-start}
 .su-self-end{align-self:flex-end}
 .su-self-stretch{align-self:stretch}
 .su-overflow-hidden{overflow:hidden}
@@ -3053,6 +3392,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-border-l{border-left-width:1px}
 .su-border-l-2{border-left-width:2px}
 .su-border-l-5{border-left-width:5px}
+.su-border-r{border-right-width:1px}
 .su-border-t{border-top-width:1px}
 .su-border-none{border-style:none}
 .su-border-black{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
@@ -3069,8 +3409,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-border-digital-red{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
 .su-border-transparent{border-color:transparent}
 .su-border-white{--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity))}
+.su-border-b-black{--tw-border-opacity:1;border-bottom-color:rgb(46 45 41 / var(--tw-border-opacity))}
 .su-border-b-black-20{--tw-border-opacity:1;border-bottom-color:rgb(213 213 212 / var(--tw-border-opacity))}
+.su-border-b-black-30{--tw-border-opacity:1;border-bottom-color:rgb(192 192 191 / var(--tw-border-opacity))}
 .su-border-b-black-70{--tw-border-opacity:1;border-bottom-color:rgb(109 108 105 / var(--tw-border-opacity))}
+.su-border-b-transparent{border-bottom-color:transparent}
+.su-border-r-black-30{--tw-border-opacity:1;border-right-color:rgb(192 192 191 / var(--tw-border-opacity))}
 .su-border-t-black-40{--tw-border-opacity:1;border-top-color:rgb(171 171 169 / var(--tw-border-opacity))}
 .su-bg-black{--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
 .su-bg-black-10{--tw-bg-opacity:1;background-color:rgb(234 234 234 / var(--tw-bg-opacity))}
@@ -3094,6 +3438,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-bg-gradient-to-l{background-image:linear-gradient(to left, var(--tw-gradient-stops))}
 .su-bg-gradient-to-r{background-image:linear-gradient(to right, var(--tw-gradient-stops))}
 .su-bg-gradient-to-t{background-image:linear-gradient(to top, var(--tw-gradient-stops))}
+.su-from-black{--tw-gradient-from:#2E2D29 var(--tw-gradient-from-position);--tw-gradient-to:rgb(46 45 41 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-black-true{--tw-gradient-from:#000000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-black-true\/75{--tw-gradient-from:rgb(0 0 0 / 0.75) var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
 .su-from-black-true\/80{--tw-gradient-from:rgb(0 0 0 / 0.8) var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
@@ -3104,6 +3449,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-via-\[rgb\(255_255_255\/\.5\)_8\%\]{--tw-gradient-to:rgb(255 255 255 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(255 255 255/.5) 8% var(--tw-gradient-via-position), var(--tw-gradient-to)}
 .su-via-black-true{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #000000 var(--tw-gradient-via-position), var(--tw-gradient-to)}
 .su-via-black-true\/10{--tw-gradient-to:rgb(0 0 0 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(0 0 0 / 0.1) var(--tw-gradient-via-position), var(--tw-gradient-to)}
+.su-via-digital-red-light{--tw-gradient-to:rgb(229 8 8 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #E50808 var(--tw-gradient-via-position), var(--tw-gradient-to)}
 .su-via-80\%{--tw-gradient-via-position:80%}
 .su-to-black-true{--tw-gradient-to:#000000 var(--tw-gradient-to-position)}
 .su-to-black-true\/60{--tw-gradient-to:rgb(0 0 0 / 0.6) var(--tw-gradient-to-position)}
@@ -3112,10 +3458,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-to-digital-red-dark{--tw-gradient-to:#820000 var(--tw-gradient-to-position)}
 .su-to-digital-red-light{--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
 .su-to-olive{--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+.su-to-plum{--tw-gradient-to:#620059 var(--tw-gradient-to-position)}
+.su-to-transparent{--tw-gradient-to:transparent var(--tw-gradient-to-position)}
 .su-to-50\%{--tw-gradient-to-position:50%}
 .su-bg-cover{background-size:cover}
 .su-bg-center{background-position:center}
 .su-bg-repeat{background-repeat:repeat}
+.su-fill-current{fill:currentColor}
 .su-fill-none{fill:none}
 .su-fill-transparent{fill:transparent}
 .su-fill-white{fill:#fff}
@@ -3133,21 +3482,30 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-p-0{padding:0}
 .su-p-10{padding:1rem}
 .su-p-12{padding:1.2rem}
+.su-p-14{padding:1.4rem}
 .su-p-15{padding:1.5rem}
 .su-p-20{padding:2rem}
 .su-p-3{padding:0.3rem}
 .su-p-34{padding:3.4rem}
+.su-p-36{padding:3.6rem}
 .su-p-38{padding:3.8rem}
+.su-p-48{padding:4.8rem}
 .su-p-7{padding:0.7rem}
 .su-p-9{padding:0.9rem}
 .su-px-0{padding-left:0;padding-right:0}
 .su-px-20{padding-left:2rem;padding-right:2rem}
 .su-px-22{padding-left:2.2rem;padding-right:2.2rem}
+.su-px-29{padding-left:2.9rem;padding-right:2.9rem}
 .su-px-30{padding-left:3rem;padding-right:3rem}
 .su-px-32{padding-left:3.2rem;padding-right:3.2rem}
+.su-px-35{padding-left:3.5rem;padding-right:3.5rem}
+.su-px-36{padding-left:3.6rem;padding-right:3.6rem}
 .su-px-38{padding-left:3.8rem;padding-right:3.8rem}
+.su-px-44{padding-left:4.4rem;padding-right:4.4rem}
+.su-px-49{padding-left:4.9rem;padding-right:4.9rem}
 .su-px-5{padding-left:0.5rem;padding-right:0.5rem}
 .su-px-50{padding-left:5rem;padding-right:5rem}
+.su-px-65{padding-left:6.5rem;padding-right:6.5rem}
 .su-py-0{padding-top:0;padding-bottom:0}
 .su-py-10{padding-top:1rem;padding-bottom:1rem}
 .su-py-14{padding-top:1.4rem;padding-bottom:1.4rem}
@@ -3156,8 +3514,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-py-20{padding-top:2rem;padding-bottom:2rem}
 .su-py-26{padding-top:2.6rem;padding-bottom:2.6rem}
 .su-py-30{padding-top:3rem;padding-bottom:3rem}
+.su-py-36{padding-top:3.6rem;padding-bottom:3.6rem}
 .su-py-38{padding-top:3.8rem;padding-bottom:3.8rem}
 .su-py-45{padding-top:4.5rem;padding-bottom:4.5rem}
+.su-py-61{padding-top:6.1rem;padding-bottom:6.1rem}
+.su-py-72{padding-top:7.2rem;padding-bottom:7.2rem}
+.su-pb-0{padding-bottom:0}
 .su-pb-10{padding-bottom:1rem}
 .su-pb-108{padding-bottom:10.8rem}
 .su-pb-11{padding-bottom:1.1rem}
@@ -3165,31 +3527,41 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pb-13{padding-bottom:1.3rem}
 .su-pb-14{padding-bottom:1.4rem}
 .su-pb-15{padding-bottom:1.5rem}
+.su-pb-16{padding-bottom:1.6rem}
 .su-pb-19{padding-bottom:1.9rem}
 .su-pb-20{padding-bottom:2rem}
 .su-pb-22{padding-bottom:2.2rem}
+.su-pb-25{padding-bottom:2.5rem}
 .su-pb-26{padding-bottom:2.6rem}
 .su-pb-27{padding-bottom:2.7rem}
 .su-pb-32{padding-bottom:3.2rem}
+.su-pb-36{padding-bottom:3.6rem}
 .su-pb-60{padding-bottom:6rem}
+.su-pb-72{padding-bottom:7.2rem}
 .su-pb-8{padding-bottom:0.8rem}
 .su-pb-80{padding-bottom:8rem}
 .su-pb-9{padding-bottom:0.9rem}
+.su-pb-95{padding-bottom:9.5rem}
 .su-pb-\[1\.1rem\]{padding-bottom:1.1rem}
 .su-pb-\[11rem\]{padding-bottom:11rem}
+.su-pb-\[13\.9rem\]{padding-bottom:13.9rem}
 .su-pb-\[171px\]{padding-bottom:171px}
 .su-pb-\[1rem\]{padding-bottom:1rem}
+.su-pb-\[20px\]{padding-bottom:20px}
 .su-pb-\[56\.25\%\]{padding-bottom:56.25%}
 .su-pl-0{padding-left:0}
 .su-pl-13{padding-left:1.3rem}
 .su-pl-15{padding-left:1.5rem}
 .su-pl-170{padding-left:17rem}
 .su-pl-20{padding-left:2rem}
+.su-pl-200{padding-left:20rem}
 .su-pl-25{padding-left:2.5rem}
+.su-pl-27{padding-left:2.7rem}
 .su-pl-30{padding-left:3rem}
 .su-pl-32{padding-left:3.2rem}
 .su-pl-38{padding-left:3.8rem}
 .su-pl-39{padding-left:3.9rem}
+.su-pl-48{padding-left:4.8rem}
 .su-pl-50{padding-left:5rem}
 .su-pl-\[calc\(16\.666\%\+10px\)\]{padding-left:calc(16.666% + 10px)}
 .su-pr-0{padding-right:0}
@@ -3201,24 +3573,31 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-pr-40{padding-right:4rem}
 .su-pr-45{padding-right:4.5rem}
 .su-pr-50{padding-right:5rem}
+.su-pr-72{padding-right:7.2rem}
 .su-pt-0{padding-top:0}
 .su-pt-10{padding-top:1rem}
+.su-pt-110{padding-top:11rem}
 .su-pt-12{padding-top:1.2rem}
 .su-pt-126{padding-top:12.6rem}
 .su-pt-13{padding-top:1.3rem}
+.su-pt-14{padding-top:1.4rem}
 .su-pt-15{padding-top:1.5rem}
 .su-pt-20{padding-top:2rem}
 .su-pt-21{padding-top:2.1rem}
+.su-pt-27{padding-top:2.7rem}
 .su-pt-300{padding-top:30rem}
 .su-pt-32{padding-top:3.2rem}
 .su-pt-34{padding-top:3.4rem}
+.su-pt-36{padding-top:3.6rem}
 .su-pt-38{padding-top:3.8rem}
+.su-pt-45{padding-top:4.5rem}
 .su-pt-49{padding-top:4.9rem}
 .su-pt-70{padding-top:7rem}
 .su-pt-9{padding-top:0.9rem}
 .su-pt-\[\.9rem\]{padding-top:.9rem}
 .su-pt-\[11\.4rem\]{padding-top:11.4rem}
 .su-pt-\[115px\]{padding-top:115px}
+.su-pt-\[20px\]{padding-top:20px}
 .su-pt-\[249px\]{padding-top:249px}
 .su-text-left{text-align:left}
 .su-text-center{text-align:center}
@@ -3232,6 +3611,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-text-14{font-size:1.4rem}
 .su-text-15{font-size:1.5rem}
 .su-text-16{font-size:1.6rem}
+.su-text-17{font-size:1.7rem}
 .su-text-18{font-size:1.8rem}
 .su-text-19{font-size:1.9rem}
 .su-text-20{font-size:2rem}
@@ -3303,6 +3683,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-leading-\[21\.6px\]{line-height:21.6px}
 .su-leading-\[21px\]{line-height:21px}
 .su-leading-\[22\.5px\]{line-height:22.5px}
+.su-leading-\[22px\]{line-height:22px}
 .su-leading-\[23\.4px\]{line-height:23.4px}
 .su-leading-\[23\.75px\]{line-height:23.75px}
 .su-leading-\[23\.88px\]{line-height:23.88px}
@@ -3366,6 +3747,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-shadow-black-60{--tw-shadow-color:#767674;--tw-shadow:var(--tw-shadow-colored)}
 .su-shadow-black-60\/50{--tw-shadow-color:rgb(118 118 116 / 0.5);--tw-shadow:var(--tw-shadow-colored)}
 .su-shadow-white{--tw-shadow-color:#fff;--tw-shadow:var(--tw-shadow-colored)}
+.su-ring{--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
 .su-ring-2{--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
 .su-ring-digital-blue-vivid{--tw-ring-opacity:1;--tw-ring-color:rgb(5 151 255 / var(--tw-ring-opacity))}
 .su-ring-white{--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
@@ -3392,9 +3774,9 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 [data-component="content-carousel"]
   .component-slider
   .component-slider-controls{margin-top:2.7rem;align-content:flex-start;align-items:flex-start;gap:1.9rem;border-top-width:1px;--tw-border-opacity:1;border-top-color:rgb(171 171 169 / var(--tw-border-opacity));padding-top:2.1rem}
-[data-component="content-carousel"]
+:is(.su-dark [data-component="content-carousel"]
   .component-slider
-  .component-slider-controls:is(.su-dark *){--tw-border-opacity:1;border-top-color:rgb(109 108 105 / var(--tw-border-opacity))}
+  .component-slider-controls){--tw-border-opacity:1;border-top-color:rgb(109 108 105 / var(--tw-border-opacity))}
 [data-component="content-carousel"]
   .component-slider
   .swiper-pagination-horizontal.swiper-pagination-bullets
@@ -3407,18 +3789,18 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
   .component-slider
   .swiper-pagination-horizontal.swiper-pagination-bullets
   .swiper-pagination-bullet:focus{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
-[data-component="content-carousel"]
+:is(.su-dark [data-component="content-carousel"]
   .component-slider
   .swiper-pagination-horizontal.swiper-pagination-bullets
-  .swiper-pagination-bullet:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity))}
-[data-component="content-carousel"]
+  .swiper-pagination-bullet){--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity))}
+:is(.su-dark [data-component="content-carousel"]
   .component-slider
   .swiper-pagination-horizontal.swiper-pagination-bullets
-  .swiper-pagination-bullet:hover:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
-[data-component="content-carousel"]
+  .swiper-pagination-bullet:hover){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark [data-component="content-carousel"]
   .component-slider
   .swiper-pagination-horizontal.swiper-pagination-bullets
-  .swiper-pagination-bullet:focus:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+  .swiper-pagination-bullet:focus){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
 [data-component="content-carousel"]
   .component-slider
   .swiper-pagination-horizontal.swiper-pagination-bullets
@@ -3431,24 +3813,24 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
   .component-slider
   .swiper-pagination-horizontal.swiper-pagination-bullets
   .swiper-pagination-bullet.swiper-pagination-bullet-active:focus{--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
-[data-component="content-carousel"]
+:is(.su-dark [data-component="content-carousel"]
   .component-slider
   .swiper-pagination-horizontal.swiper-pagination-bullets
-  .swiper-pagination-bullet.swiper-pagination-bullet-active:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(255 255 255 / var(--tw-bg-opacity))}
-[data-component="content-carousel"]
+  .swiper-pagination-bullet.swiper-pagination-bullet-active){--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(255 255 255 / var(--tw-bg-opacity))}
+:is(.su-dark [data-component="content-carousel"]
   .component-slider
   .swiper-pagination-horizontal.swiper-pagination-bullets
-  .swiper-pagination-bullet.swiper-pagination-bullet-active:hover:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity))}
-[data-component="content-carousel"]
+  .swiper-pagination-bullet.swiper-pagination-bullet-active:hover){--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity))}
+:is(.su-dark [data-component="content-carousel"]
   .component-slider
   .swiper-pagination-horizontal.swiper-pagination-bullets
-  .swiper-pagination-bullet.swiper-pagination-bullet-active:focus:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity))}
+  .swiper-pagination-bullet.swiper-pagination-bullet-active:focus){--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity))}
 [data-component="content-carousel"] .component-slider .component-slider-btn{--tw-border-opacity:1;border-color:rgb(213 213 212 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(255 255 255 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
 [data-component="content-carousel"] .component-slider .component-slider-btn:hover{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 [data-component="content-carousel"] .component-slider .component-slider-btn:focus{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(177 4 14 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-[data-component="content-carousel"] .component-slider .component-slider-btn:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(109 108 105 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-[data-component="content-carousel"] .component-slider .component-slider-btn:hover:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-[data-component="content-carousel"] .component-slider .component-slider-btn:focus:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark [data-component="content-carousel"] .component-slider .component-slider-btn){--tw-border-opacity:1;border-color:rgb(109 108 105 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark [data-component="content-carousel"] .component-slider .component-slider-btn:hover){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark [data-component="content-carousel"] .component-slider .component-slider-btn:focus){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity));--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity));--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 [data-component="content-carousel"] .su-wysiwyg-content > *:first-child {
   margin-top: 0;
 }
@@ -3598,11 +3980,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .report-header__pref-toggle::before{position:absolute;top:0;bottom:0;right:0;left:0;z-index:-10;margin:-0.2rem;content:var(--tw-content);transition-property:color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;transition-timing-function:cubic-bezier(0.4, 0, 0.2, 1);transition-duration:250ms}
 .report-header__pref-toggle::after{position:absolute;top:0;bottom:0;right:0;left:0;z-index:-10;content:var(--tw-content);transition-property:none}
 .report-header__pref-toggle:hover{background-color:transparent}
-.report-header__pref-toggle:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
-.report-header__pref-toggle:is(.su-dark *)::after{content:var(--tw-content);--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
-.report-header__pref-toggle:hover:is(.su-dark *){background-color:transparent;--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.report-header__pref-toggle[aria-pressed="true"]:is(.su-dark *){background-color:transparent}
-.report-header__pref-toggle:is(.su-dark *)[aria-pressed="true"]{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .report-header__pref-toggle){--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
+:is(.su-dark .report-header__pref-toggle)::after{content:var(--tw-content);--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+:is(.su-dark .report-header__pref-toggle:hover){background-color:transparent;--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .report-header__pref-toggle[aria-pressed="true"]){background-color:transparent}
+:is(.su-dark .report-header__pref-toggle)[aria-pressed="true"]{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 .report-header__pref-toggle {
   border-radius: 9px;
   background-clip: padding-box;
@@ -3886,7 +4268,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
   justify-content: space-between;
 }
 .pre-footer-links-wrapper .pre-footer-links .pre-footer-links-inner::before{background-image:linear-gradient(to bottom, var(--tw-gradient-stops));--tw-gradient-from:#820000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(130 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#E50808 var(--tw-gradient-to-position)}
-.pre-footer-links-wrapper .pre-footer-links .pre-footer-links-inner:is(.su-dark *)::before{--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+:is(.su-dark .pre-footer-links-wrapper .pre-footer-links .pre-footer-links-inner)::before{--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to);--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
 .pre-footer-links-wrapper .pre-footer-links h2 {
   font-size: 18px;
   font-style: normal;
@@ -4144,6 +4526,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .last\:\*\:su-mb-0 > *:last-child{margin-bottom:0}
 .focus-within\:su-shadow-md:focus-within{--tw-shadow:0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);--tw-shadow-colored:0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
 .focus-within\:su-ring-4:focus-within{--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
+.hover\:su-border-black-40:hover{--tw-border-opacity:1;border-color:rgb(171 171 169 / var(--tw-border-opacity))}
 .hover\:su-border-black-70:hover{--tw-border-opacity:1;border-color:rgb(109 108 105 / var(--tw-border-opacity))}
 .hover\:su-border-digital-red:hover{--tw-border-opacity:1;border-color:rgb(177 4 14 / var(--tw-border-opacity))}
 .hover\:su-bg-black:hover{--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
@@ -4282,122 +4665,123 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-group:hover .group-hocus-within\:su-text-digital-red{--tw-text-opacity:1;color:rgb(177 4 14 / var(--tw-text-opacity))}
 .su-group:hover .group-hocus-within\:su-text-digital-red-light{--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 .su-group:hover .group-hocus-within\:su-underline{text-decoration-line:underline}
-.dark\:su-top-0:is(.su-dark *){top:0}
-.dark\:su-block:is(.su-dark *){display:block}
-.dark\:su-flex:is(.su-dark *){display:flex}
-.dark\:su-hidden:is(.su-dark *){display:none}
-.dark\:su-rotate-180:is(.su-dark *){--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
-.dark\:su-divide-black-60:is(.su-dark *) > :not([hidden]) ~ :not([hidden]){--tw-divide-opacity:1;border-color:rgb(118 118 116 / var(--tw-divide-opacity))}
-.dark\:su-border-2:is(.su-dark *){border-width:2px}
-.dark\:su-border-black:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
-.dark\:su-border-black-20:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(213 213 212 / var(--tw-border-opacity))}
-.dark\:su-border-black-60:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity))}
-.dark\:su-border-black-70:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(109 108 105 / var(--tw-border-opacity))}
-.dark\:su-border-black-true:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(0 0 0 / var(--tw-border-opacity))}
-.dark\:su-border-dark-mode-red:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
-.dark\:su-border-white:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity))}
-.dark\:su-border-b-black-30:is(.su-dark *){--tw-border-opacity:1;border-bottom-color:rgb(192 192 191 / var(--tw-border-opacity))}
-.dark\:su-border-b-black-70:is(.su-dark *){--tw-border-opacity:1;border-bottom-color:rgb(109 108 105 / var(--tw-border-opacity))}
-.dark\:su-bg-black:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
-.dark\:su-bg-black-60:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(118 118 116 / var(--tw-bg-opacity))}
-.dark\:su-bg-black-70:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(109 108 105 / var(--tw-bg-opacity))}
-.dark\:su-bg-black-true:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
-.dark\:su-bg-black\/\[0\.5\]:is(.su-dark *){background-color:rgb(46 45 41 / 0.5)}
-.dark\:su-bg-dark-mode-red:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
-.dark\:su-bg-olive:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(143 153 62 / var(--tw-bg-opacity))}
-.dark\:su-bg-transparent:is(.su-dark *){background-color:transparent}
-.dark\:su-bg-white:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(255 255 255 / var(--tw-bg-opacity))}
-.dark\:su-bg-gradient-to-tl:is(.su-dark *){background-image:linear-gradient(to top left, var(--tw-gradient-stops))}
-.dark\:su-from-black-true:is(.su-dark *){--tw-gradient-from:#000000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
-.dark\:su-from-olive:is(.su-dark *){--tw-gradient-from:#8F993E var(--tw-gradient-from-position);--tw-gradient-to:rgb(143 153 62 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
-.dark\:su-from-palo-verde:is(.su-dark *){--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
-.dark\:su-via-\[rgb\(0_0_0\/\.5\)_8\%\]:is(.su-dark *){--tw-gradient-to:rgb(255 255 255 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(0 0 0/.5) 8% var(--tw-gradient-via-position), var(--tw-gradient-to)}
-.dark\:su-via-palo-verde:is(.su-dark *){--tw-gradient-to:rgb(39 153 137 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #279989 var(--tw-gradient-via-position), var(--tw-gradient-to)}
-.dark\:su-to-olive:is(.su-dark *){--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
-.dark\:su-to-palo-verde:is(.su-dark *){--tw-gradient-to:#279989 var(--tw-gradient-to-position)}
-.dark\:su-stroke-dark-mode-red:is(.su-dark *){stroke:#EC0909}
-.dark\:\!su-text-dark-mode-red:is(.su-dark *){--tw-text-opacity:1 !important;color:rgb(236 9 9 / var(--tw-text-opacity)) !important}
-.dark\:su-text-\[white\]:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:su-text-black:is(.su-dark *){--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-.dark\:su-text-black-20:is(.su-dark *){--tw-text-opacity:1;color:rgb(213 213 212 / var(--tw-text-opacity))}
-.dark\:su-text-black-30:is(.su-dark *){--tw-text-opacity:1;color:rgb(192 192 191 / var(--tw-text-opacity))}
-.dark\:su-text-black-40:is(.su-dark *){--tw-text-opacity:1;color:rgb(171 171 169 / var(--tw-text-opacity))}
-.dark\:su-text-black-50:is(.su-dark *){--tw-text-opacity:1;color:rgb(151 150 148 / var(--tw-text-opacity))}
-.dark\:su-text-black-60:is(.su-dark *){--tw-text-opacity:1;color:rgb(118 118 116 / var(--tw-text-opacity))}
-.dark\:su-text-black-true:is(.su-dark *){--tw-text-opacity:1;color:rgb(0 0 0 / var(--tw-text-opacity))}
-.dark\:su-text-dark-mode-red:is(.su-dark *){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-.dark\:su-text-digital-blue-vivid:is(.su-dark *){--tw-text-opacity:1;color:rgb(5 151 255 / var(--tw-text-opacity))}
-.dark\:su-text-palo-verde:is(.su-dark *){--tw-text-opacity:1;color:rgb(39 153 137 / var(--tw-text-opacity))}
-.dark\:su-text-white:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:su-shadow-\[0_3px_6px_0_rgba\(46\2c 45\2c 41\2c 0\.5\)\]:is(.su-dark *){--tw-shadow:0 3px 6px 0 rgba(46,45,41,0.5);--tw-shadow-colored:0 3px 6px 0 var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
-.dark\:su-shadow-\[0px_-3px_6px_0px_rgba\(46\2c 45\2c 41\2c 0\.5\)\]:is(.su-dark *){--tw-shadow:0px -3px 6px 0px rgba(46,45,41,0.5);--tw-shadow-colored:0px -3px 6px 0px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
-.dark\:su-shadow-\[inset_0_0_0_2px_rgba\(236\2c 9\2c 9\2c 1\)\]:is(.su-dark *){--tw-shadow:inset 0 0 0 2px rgba(236,9,9,1);--tw-shadow-colored:inset 0 0 0 2px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
-.dark\:su-shadow-black-true:is(.su-dark *){--tw-shadow-color:#000000;--tw-shadow:var(--tw-shadow-colored)}
-.dark\:su-shadow-black\/80:is(.su-dark *){--tw-shadow-color:rgb(46 45 41 / 0.8);--tw-shadow:var(--tw-shadow-colored)}
-.\*\:dark\:su-text-black:is(.su-dark *) > *{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
-.\*\:dark\:su-text-white:is(.su-dark *) > *{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:placeholder\:su-text-white:is(.su-dark *)::placeholder{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:before\:su-absolute:is(.su-dark *)::before{content:var(--tw-content);position:absolute}
-.dark\:before\:su-left-0:is(.su-dark *)::before{content:var(--tw-content);left:0}
-.dark\:before\:su-top-0:is(.su-dark *)::before{content:var(--tw-content);top:0}
-.dark\:before\:su-h-full:is(.su-dark *)::before{content:var(--tw-content);height:100%}
-.dark\:before\:su-w-full:is(.su-dark *)::before{content:var(--tw-content);width:100%}
-.dark\:before\:su-rotate-180:is(.su-dark *)::before{content:var(--tw-content);--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
-.dark\:before\:su-bg-black:is(.su-dark *)::before{content:var(--tw-content);--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
-.dark\:before\:su-text-white:is(.su-dark *)::before{content:var(--tw-content);--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:before\:su-opacity-\[0\.5\]:is(.su-dark *)::before{content:var(--tw-content);opacity:0.5}
-.dark\:before\:su-content-\[\'\'\]:is(.su-dark *)::before{--tw-content:'';content:var(--tw-content)}
-.dark\:after\:su-rotate-180:is(.su-dark *)::after{content:var(--tw-content);--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
-.dark\:hover\:su-border-dark-mode-red:hover:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
-.dark\:hover\:su-bg-transparent:hover:is(.su-dark *){background-color:transparent}
-.dark\:hover\:su-text-dark-mode-red:hover:is(.su-dark *){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-.dark\:hover\:su-text-white:hover:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.hover\:dark\:su-text-dark-mode-red:is(.su-dark *):hover{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-.dark\:focus\:su-border-digital-blue-vivid:focus:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(5 151 255 / var(--tw-border-opacity))}
-.dark\:focus\:su-ring-digital-blue-vivid\/60:focus:is(.su-dark *){--tw-ring-color:rgb(5 151 255 / 0.6)}
-.dark\:focus-visible\:su-ring-dark-mode-red:focus-visible:is(.su-dark *){--tw-ring-opacity:1;--tw-ring-color:rgb(236 9 9 / var(--tw-ring-opacity))}
-.dark\:focus-visible\:su-ring-white:focus-visible:is(.su-dark *){--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
-.dark\:focus-visible\:after\:su-outline-dark-mode-red:focus-visible:is(.su-dark *)::after{content:var(--tw-content);outline-color:#EC0909}
-.su-peer\/dark:checked ~ .dark\:peer-checked\/dark\:su-text-palo-verde:is(.su-dark *){--tw-text-opacity:1;color:rgb(39 153 137 / var(--tw-text-opacity))}
-.dark\:aria-expanded\:su-text-black-true[aria-expanded="true"]:is(.su-dark *){--tw-text-opacity:1;color:rgb(0 0 0 / var(--tw-text-opacity))}
-.dark\:aria-pressed\:su-bg-transparent[aria-pressed="true"]:is(.su-dark *){background-color:transparent}
-.aria-pressed\:dark\:su-text-white:is(.su-dark *)[aria-pressed="true"]{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:aria-pressed\:su-text-black-true[aria-pressed="true"]:is(.su-dark *){--tw-text-opacity:1;color:rgb(0 0 0 / var(--tw-text-opacity))}
-.dark\:aria-pressed\:su-text-white[aria-pressed="true"]:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:hocus\:su-border-dark-mode-red:hover:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
-.dark\:hocus\:su-border-digital-blue-light\/80:hover:is(.su-dark *){border-color:rgb(133 204 255 / 0.8)}
-.dark\:hocus\:su-border-b-digital-blue-light:hover:is(.su-dark *){--tw-border-opacity:1;border-bottom-color:rgb(133 204 255 / var(--tw-border-opacity))}
-.dark\:hocus\:su-bg-dark-mode-red:hover:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
-.dark\:hocus\:su-text-dark-mode-red:hover:is(.su-dark *){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-.dark\:hocus\:su-text-white:hover:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:hocus\:su-text-white\/95:hover:is(.su-dark *){color:rgb(255 255 255 / 0.95)}
-.hocus\:dark\:su-text-dark-mode-red:is(.su-dark *):hover{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-.hocus\:dark\:su-text-white:is(.su-dark *):hover{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(236\2c 9\2c 9\2c 1\)\]:hover:is(.su-dark *){--tw-shadow:inset 0 0 0 3px rgba(236,9,9,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
-.dark\:hocus\:su-ring-1:hover:is(.su-dark *){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
-.dark\:hocus\:su-ring-2:hover:is(.su-dark *){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
-.dark\:hocus\:su-ring-white:hover:is(.su-dark *){--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
-.dark\:hocus\:su-border-dark-mode-red:focus:is(.su-dark *){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
-.dark\:hocus\:su-border-digital-blue-light\/80:focus:is(.su-dark *){border-color:rgb(133 204 255 / 0.8)}
-.dark\:hocus\:su-border-b-digital-blue-light:focus:is(.su-dark *){--tw-border-opacity:1;border-bottom-color:rgb(133 204 255 / var(--tw-border-opacity))}
-.dark\:hocus\:su-bg-dark-mode-red:focus:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
-.dark\:hocus\:su-text-dark-mode-red:focus:is(.su-dark *){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-.dark\:hocus\:su-text-white:focus:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:hocus\:su-text-white\/95:focus:is(.su-dark *){color:rgb(255 255 255 / 0.95)}
-.hocus\:dark\:su-text-dark-mode-red:is(.su-dark *):focus{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-.hocus\:dark\:su-text-white:is(.su-dark *):focus{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(236\2c 9\2c 9\2c 1\)\]:focus:is(.su-dark *){--tw-shadow:inset 0 0 0 3px rgba(236,9,9,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
-.dark\:hocus\:su-ring-1:focus:is(.su-dark *){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
-.dark\:hocus\:su-ring-2:focus:is(.su-dark *){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
-.dark\:hocus\:su-ring-white:focus:is(.su-dark *){--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
-.dark\:hocus-visible\:su-text-white:hover:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.dark\:hocus-visible\:su-text-white:focus-visible:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.su-group:focus .dark\:group-hocus\:su-text-dark-mode-red:is(.su-dark *){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-.su-group:focus .dark\:group-hocus\:su-text-white:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.su-group:hover .dark\:group-hocus\:su-text-dark-mode-red:is(.su-dark *){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
-.su-group:hover .dark\:group-hocus\:su-text-white:is(.su-dark *){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-.su-group:focus-within .dark\:group-hocus-within\:su-text-digital-red-light:is(.su-dark *){--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
-.su-group:hover .dark\:group-hocus-within\:su-text-digital-red-light:is(.su-dark *){--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-top-0){top:0}
+:is(.su-dark .dark\:su-block){display:block}
+:is(.su-dark .dark\:su-flex){display:flex}
+:is(.su-dark .dark\:su-hidden){display:none}
+:is(.su-dark .dark\:su-rotate-180){--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+:is(.su-dark .dark\:su-divide-black-60) > :not([hidden]) ~ :not([hidden]){--tw-divide-opacity:1;border-color:rgb(118 118 116 / var(--tw-divide-opacity))}
+:is(.su-dark .dark\:su-border-2){border-width:2px}
+:is(.su-dark .dark\:su-border-black){--tw-border-opacity:1;border-color:rgb(46 45 41 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:su-border-black-20){--tw-border-opacity:1;border-color:rgb(213 213 212 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:su-border-black-60){--tw-border-opacity:1;border-color:rgb(118 118 116 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:su-border-black-70){--tw-border-opacity:1;border-color:rgb(109 108 105 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:su-border-black-true){--tw-border-opacity:1;border-color:rgb(0 0 0 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:su-border-dark-mode-red){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:su-border-white){--tw-border-opacity:1;border-color:rgb(255 255 255 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:su-border-b-black){--tw-border-opacity:1;border-bottom-color:rgb(46 45 41 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:su-border-b-black-30){--tw-border-opacity:1;border-bottom-color:rgb(192 192 191 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:su-border-b-black-70){--tw-border-opacity:1;border-bottom-color:rgb(109 108 105 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:su-bg-black){--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
+:is(.su-dark .dark\:su-bg-black-60){--tw-bg-opacity:1;background-color:rgb(118 118 116 / var(--tw-bg-opacity))}
+:is(.su-dark .dark\:su-bg-black-70){--tw-bg-opacity:1;background-color:rgb(109 108 105 / var(--tw-bg-opacity))}
+:is(.su-dark .dark\:su-bg-black-true){--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
+:is(.su-dark .dark\:su-bg-black\/\[0\.5\]){background-color:rgb(46 45 41 / 0.5)}
+:is(.su-dark .dark\:su-bg-dark-mode-red){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
+:is(.su-dark .dark\:su-bg-olive){--tw-bg-opacity:1;background-color:rgb(143 153 62 / var(--tw-bg-opacity))}
+:is(.su-dark .dark\:su-bg-transparent){background-color:transparent}
+:is(.su-dark .dark\:su-bg-white){--tw-bg-opacity:1;background-color:rgb(255 255 255 / var(--tw-bg-opacity))}
+:is(.su-dark .dark\:su-bg-gradient-to-tl){background-image:linear-gradient(to top left, var(--tw-gradient-stops))}
+:is(.su-dark .dark\:su-from-black-true){--tw-gradient-from:#000000 var(--tw-gradient-from-position);--tw-gradient-to:rgb(0 0 0 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
+:is(.su-dark .dark\:su-from-olive){--tw-gradient-from:#8F993E var(--tw-gradient-from-position);--tw-gradient-to:rgb(143 153 62 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
+:is(.su-dark .dark\:su-from-palo-verde){--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
+:is(.su-dark .dark\:su-via-\[rgb\(0_0_0\/\.5\)_8\%\]){--tw-gradient-to:rgb(255 255 255 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), rgb(0 0 0/.5) 8% var(--tw-gradient-via-position), var(--tw-gradient-to)}
+:is(.su-dark .dark\:su-via-palo-verde){--tw-gradient-to:rgb(39 153 137 / 0)  var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), #279989 var(--tw-gradient-via-position), var(--tw-gradient-to)}
+:is(.su-dark .dark\:su-to-olive){--tw-gradient-to:#8F993E var(--tw-gradient-to-position)}
+:is(.su-dark .dark\:su-to-palo-verde){--tw-gradient-to:#279989 var(--tw-gradient-to-position)}
+:is(.su-dark .dark\:su-stroke-dark-mode-red){stroke:#EC0909}
+:is(.su-dark .dark\:\!su-text-dark-mode-red){--tw-text-opacity:1 !important;color:rgb(236 9 9 / var(--tw-text-opacity)) !important}
+:is(.su-dark .dark\:su-text-\[white\]){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-black){--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-black-20){--tw-text-opacity:1;color:rgb(213 213 212 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-black-30){--tw-text-opacity:1;color:rgb(192 192 191 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-black-40){--tw-text-opacity:1;color:rgb(171 171 169 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-black-50){--tw-text-opacity:1;color:rgb(151 150 148 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-black-60){--tw-text-opacity:1;color:rgb(118 118 116 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-black-true){--tw-text-opacity:1;color:rgb(0 0 0 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-dark-mode-red){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-digital-blue-vivid){--tw-text-opacity:1;color:rgb(5 151 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-palo-verde){--tw-text-opacity:1;color:rgb(39 153 137 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-text-white){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:su-shadow-\[0_3px_6px_0_rgba\(46\2c 45\2c 41\2c 0\.5\)\]){--tw-shadow:0 3px 6px 0 rgba(46,45,41,0.5);--tw-shadow-colored:0 3px 6px 0 var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
+:is(.su-dark .dark\:su-shadow-\[0px_-3px_6px_0px_rgba\(46\2c 45\2c 41\2c 0\.5\)\]){--tw-shadow:0px -3px 6px 0px rgba(46,45,41,0.5);--tw-shadow-colored:0px -3px 6px 0px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
+:is(.su-dark .dark\:su-shadow-\[inset_0_0_0_2px_rgba\(236\2c 9\2c 9\2c 1\)\]){--tw-shadow:inset 0 0 0 2px rgba(236,9,9,1);--tw-shadow-colored:inset 0 0 0 2px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
+:is(.su-dark .dark\:su-shadow-black-true){--tw-shadow-color:#000000;--tw-shadow:var(--tw-shadow-colored)}
+:is(.su-dark .dark\:su-shadow-black\/80){--tw-shadow-color:rgb(46 45 41 / 0.8);--tw-shadow:var(--tw-shadow-colored)}
+:is(.su-dark .\*\:dark\:su-text-black) > *{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
+:is(.su-dark .\*\:dark\:su-text-white) > *{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:placeholder\:su-text-white)::placeholder{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:before\:su-absolute)::before{content:var(--tw-content);position:absolute}
+:is(.su-dark .dark\:before\:su-left-0)::before{content:var(--tw-content);left:0}
+:is(.su-dark .dark\:before\:su-top-0)::before{content:var(--tw-content);top:0}
+:is(.su-dark .dark\:before\:su-h-full)::before{content:var(--tw-content);height:100%}
+:is(.su-dark .dark\:before\:su-w-full)::before{content:var(--tw-content);width:100%}
+:is(.su-dark .dark\:before\:su-rotate-180)::before{content:var(--tw-content);--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+:is(.su-dark .dark\:before\:su-bg-black)::before{content:var(--tw-content);--tw-bg-opacity:1;background-color:rgb(46 45 41 / var(--tw-bg-opacity))}
+:is(.su-dark .dark\:before\:su-text-white)::before{content:var(--tw-content);--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:before\:su-opacity-\[0\.5\])::before{content:var(--tw-content);opacity:0.5}
+:is(.su-dark .dark\:before\:su-content-\[\'\'\])::before{--tw-content:'';content:var(--tw-content)}
+:is(.su-dark .dark\:after\:su-rotate-180)::after{content:var(--tw-content);--tw-rotate:180deg;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
+:is(.su-dark .dark\:hover\:su-border-dark-mode-red:hover){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:hover\:su-bg-transparent:hover){background-color:transparent}
+:is(.su-dark .dark\:hover\:su-text-dark-mode-red:hover){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:hover\:su-text-white:hover){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .hover\:dark\:su-text-dark-mode-red):hover{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:focus\:su-border-digital-blue-vivid:focus){--tw-border-opacity:1;border-color:rgb(5 151 255 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:focus\:su-ring-digital-blue-vivid\/60:focus){--tw-ring-color:rgb(5 151 255 / 0.6)}
+:is(.su-dark .dark\:focus-visible\:su-ring-dark-mode-red:focus-visible){--tw-ring-opacity:1;--tw-ring-color:rgb(236 9 9 / var(--tw-ring-opacity))}
+:is(.su-dark .dark\:focus-visible\:su-ring-white:focus-visible){--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
+:is(.su-dark .dark\:focus-visible\:after\:su-outline-dark-mode-red:focus-visible)::after{content:var(--tw-content);outline-color:#EC0909}
+:is(.su-dark .su-peer\/dark:checked ~ .dark\:peer-checked\/dark\:su-text-palo-verde){--tw-text-opacity:1;color:rgb(39 153 137 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:aria-expanded\:su-text-black-true[aria-expanded="true"]){--tw-text-opacity:1;color:rgb(0 0 0 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:aria-pressed\:su-bg-transparent[aria-pressed="true"]){background-color:transparent}
+:is(.su-dark .aria-pressed\:dark\:su-text-white)[aria-pressed="true"]{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:aria-pressed\:su-text-black-true[aria-pressed="true"]){--tw-text-opacity:1;color:rgb(0 0 0 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:aria-pressed\:su-text-white[aria-pressed="true"]){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:hocus\:su-border-dark-mode-red:hover){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:hocus\:su-border-digital-blue-light\/80:hover){border-color:rgb(133 204 255 / 0.8)}
+:is(.su-dark .dark\:hocus\:su-border-b-digital-blue-light:hover){--tw-border-opacity:1;border-bottom-color:rgb(133 204 255 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:hocus\:su-bg-dark-mode-red:hover){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
+:is(.su-dark .dark\:hocus\:su-text-dark-mode-red:hover){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:hocus\:su-text-white:hover){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:hocus\:su-text-white\/95:hover){color:rgb(255 255 255 / 0.95)}
+:is(.su-dark .hocus\:dark\:su-text-dark-mode-red):hover{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .hocus\:dark\:su-text-white):hover{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(236\2c 9\2c 9\2c 1\)\]:hover){--tw-shadow:inset 0 0 0 3px rgba(236,9,9,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
+:is(.su-dark .dark\:hocus\:su-ring-1:hover){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
+:is(.su-dark .dark\:hocus\:su-ring-2:hover){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
+:is(.su-dark .dark\:hocus\:su-ring-white:hover){--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
+:is(.su-dark .dark\:hocus\:su-border-dark-mode-red:focus){--tw-border-opacity:1;border-color:rgb(236 9 9 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:hocus\:su-border-digital-blue-light\/80:focus){border-color:rgb(133 204 255 / 0.8)}
+:is(.su-dark .dark\:hocus\:su-border-b-digital-blue-light:focus){--tw-border-opacity:1;border-bottom-color:rgb(133 204 255 / var(--tw-border-opacity))}
+:is(.su-dark .dark\:hocus\:su-bg-dark-mode-red:focus){--tw-bg-opacity:1;background-color:rgb(236 9 9 / var(--tw-bg-opacity))}
+:is(.su-dark .dark\:hocus\:su-text-dark-mode-red:focus){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:hocus\:su-text-white:focus){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:hocus\:su-text-white\/95:focus){color:rgb(255 255 255 / 0.95)}
+:is(.su-dark .hocus\:dark\:su-text-dark-mode-red):focus{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .hocus\:dark\:su-text-white):focus{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:hocus\:su-shadow-\[inset_0_0_0_3px_rgba\(236\2c 9\2c 9\2c 1\)\]:focus){--tw-shadow:inset 0 0 0 3px rgba(236,9,9,1);--tw-shadow-colored:inset 0 0 0 3px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow)}
+:is(.su-dark .dark\:hocus\:su-ring-1:focus){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
+:is(.su-dark .dark\:hocus\:su-ring-2:focus){--tw-ring-offset-shadow:var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);--tw-ring-shadow:var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);box-shadow:var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000)}
+:is(.su-dark .dark\:hocus\:su-ring-white:focus){--tw-ring-opacity:1;--tw-ring-color:rgb(255 255 255 / var(--tw-ring-opacity))}
+:is(.su-dark .dark\:hocus-visible\:su-text-white:hover){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .dark\:hocus-visible\:su-text-white:focus-visible){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .su-group:focus .dark\:group-hocus\:su-text-dark-mode-red){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .su-group:focus .dark\:group-hocus\:su-text-white){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .su-group:hover .dark\:group-hocus\:su-text-dark-mode-red){--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+:is(.su-dark .su-group:hover .dark\:group-hocus\:su-text-white){--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+:is(.su-dark .su-group:focus-within .dark\:group-hocus-within\:su-text-digital-red-light){--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
+:is(.su-dark .su-group:hover .dark\:group-hocus-within\:su-text-digital-red-light){--tw-text-opacity:1;color:rgb(229 8 8 / var(--tw-text-opacity))}
 @media (min-width: 576px){
 .sm\:su-bottom-120{bottom:12rem}
 .sm\:su-bottom-61{bottom:6.1rem}
@@ -4474,11 +4858,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-mb-\[5\.9rem\]{margin-bottom:5.9rem}
 .md\:su-mb-\[6\.05px\]{margin-bottom:6.05px}
 .md\:su-ml-19{margin-left:1.9rem}
+.md\:su-ml-\[19px\]{margin-left:19px}
 .md\:su-ml-\[8\.333\%\]{margin-left:8.333%}
 .md\:su-mr-0{margin-right:0}
 .md\:su-mr-13{margin-right:1.3rem}
 .md\:su-mr-25{margin-right:2.5rem}
 .md\:su-mr-4{margin-right:0.4rem}
+.md\:su-mr-\[13px\]{margin-right:13px}
 .md\:su-mr-\[4px\]{margin-right:4px}
 .md\:su-mt-0{margin-top:0}
 .md\:su-mt-10{margin-top:1rem}
@@ -4551,6 +4937,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-items-start{align-items:flex-start}
 .md\:su-items-end{align-items:flex-end}
 .md\:su-items-center{align-items:center}
+.md\:su-items-stretch{align-items:stretch}
 .md\:su-justify-start{justify-content:flex-start}
 .md\:su-justify-center{justify-content:center}
 .md\:su-gap-12{gap:1.2rem}
@@ -4616,8 +5003,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pb-\[1\.3rem\]{padding-bottom:1.3rem}
 .md\:su-pb-\[10px\]{padding-bottom:10px}
 .md\:su-pb-\[14px\]{padding-bottom:14px}
+.md\:su-pb-\[16\.6rem\]{padding-bottom:16.6rem}
 .md\:su-pb-\[17\.7rem\]{padding-bottom:17.7rem}
 .md\:su-pb-\[1px\]{padding-bottom:1px}
+.md\:su-pb-\[20\.05px\]{padding-bottom:20.05px}
 .md\:su-pb-\[6\.05px\]{padding-bottom:6.05px}
 .md\:su-pb-\[64px\]{padding-bottom:64px}
 .md\:su-pl-0{padding-left:0}
@@ -4635,6 +5024,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-pt-45{padding-top:4.5rem}
 .md\:su-pt-\[159px\]{padding-top:159px}
 .md\:su-pt-\[167px\]{padding-top:167px}
+.md\:su-pt-\[21px\]{padding-top:21px}
 .md\:su-pt-\[40vw\]{padding-top:40vw}
 .md\:su-text-left{text-align:left}
 .md\:su-text-center{text-align:center}
@@ -4645,6 +5035,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-text-20{font-size:2rem}
 .md\:su-text-21{font-size:2.1rem}
 .md\:su-text-22{font-size:2.2rem}
+.md\:su-text-23{font-size:2.3rem}
 .md\:su-text-24{font-size:2.4rem}
 .md\:su-text-25{font-size:2.5rem}
 .md\:su-text-26{font-size:2.6rem}
@@ -4723,8 +5114,8 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:after\:su-top-\[30\%\]::after{content:var(--tw-content);top:30%}
 .md\:after\:su-h-\[70\%\]::after{content:var(--tw-content);height:70%}
 .md\:after\:su-h-\[80\%\]::after{content:var(--tw-content);height:80%}
-.dark\:md\:su-from-olive:is(.su-dark *){--tw-gradient-from:#8F993E var(--tw-gradient-from-position);--tw-gradient-to:rgb(143 153 62 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
-.dark\:md\:su-from-palo-verde:is(.su-dark *){--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}}
+:is(.su-dark .dark\:md\:su-from-olive){--tw-gradient-from:#8F993E var(--tw-gradient-from-position);--tw-gradient-to:rgb(143 153 62 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}
+:is(.su-dark .dark\:md\:su-from-palo-verde){--tw-gradient-from:#279989 var(--tw-gradient-from-position);--tw-gradient-to:rgb(39 153 137 / 0) var(--tw-gradient-to-position);--tw-gradient-stops:var(--tw-gradient-from), var(--tw-gradient-to)}}
 @media (min-width: 992px){
 .lg\:su-relative{position:relative}
 .lg\:su-bottom-0{bottom:0}
@@ -4769,11 +5160,13 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-ml-38{margin-left:3.8rem}
 .lg\:su-ml-\[-10\%\]{margin-left:-10%}
 .lg\:su-ml-\[-2rem\]{margin-left:-2rem}
+.lg\:su-ml-\[26px\]{margin-left:26px}
 .lg\:su-ml-auto{margin-left:auto}
 .lg\:su-mr-0{margin-right:0}
 .lg\:su-mr-19{margin-right:1.9rem}
 .lg\:su-mr-36{margin-right:3.6rem}
 .lg\:su-mr-\[2\%\]{margin-right:2%}
+.lg\:su-mr-\[36px\]{margin-right:36px}
 .lg\:su-mt-0{margin-top:0}
 .lg\:su-mt-15{margin-top:1.5rem}
 .lg\:su-mt-162{margin-top:16.2rem}
@@ -4827,7 +5220,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-max-w-800{max-width:80rem}
 .lg\:su-max-w-\[185px\]{max-width:185px}
 .lg\:su-max-w-\[29\.2rem\]{max-width:29.2rem}
-.lg\:su-max-w-\[29\.3rem\]{max-width:29.3rem}
 .lg\:su-max-w-\[293px\]{max-width:293px}
 .lg\:su-max-w-\[296px\]{max-width:296px}
 .lg\:su-max-w-\[35\.9rem\]{max-width:35.9rem}
@@ -4895,10 +5287,12 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-py-36{padding-top:3.6rem;padding-bottom:3.6rem}
 .lg\:su-py-61{padding-top:6.1rem;padding-bottom:6.1rem}
 .lg\:su-pb-0{padding-bottom:0}
+.lg\:su-pb-16{padding-bottom:1.6rem}
 .lg\:su-pb-27{padding-bottom:2.7rem}
 .lg\:su-pb-32{padding-bottom:3.2rem}
 .lg\:su-pb-36{padding-bottom:3.6rem}
 .lg\:su-pb-\[11px\]{padding-bottom:11px}
+.lg\:su-pb-\[18\.9rem\]{padding-bottom:18.9rem}
 .lg\:su-pb-\[19\.3rem\]{padding-bottom:19.3rem}
 .lg\:su-pb-\[2px\]{padding-bottom:2px}
 .lg\:su-pb-\[8\.75px\]{padding-bottom:8.75px}
@@ -4920,6 +5314,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-pt-90{padding-top:9rem}
 .lg\:su-pt-\[17\.5rem\]{padding-top:17.5rem}
 .lg\:su-pt-\[26vw\]{padding-top:26vw}
+.lg\:su-pt-\[27px\]{padding-top:27px}
 .lg\:su-text-left{text-align:left}
 .lg\:su-text-14{font-size:1.4rem}
 .lg\:su-text-15{font-size:1.5rem}
@@ -5003,7 +5398,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:after\:su-block::after{content:var(--tw-content);display:block}
 .lg\:after\:su-hidden::after{content:var(--tw-content);display:none}
 .lg\:after\:su-h-\[calc\(100\%-16rem\)\]::after{content:var(--tw-content);height:calc(100% - 16rem)}
-.lg\:dark\:su-bg-black-true:is(.su-dark *){--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}}
+:is(.su-dark .lg\:dark\:su-bg-black-true){--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}}
 @media (min-width: 1200px){
 .xl\:su-order-2{order:2}
 .xl\:su-order-first{order:-9999}
@@ -5064,7 +5459,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\[\&\>\*\]\:su-stroke-current>*{stroke:currentColor}
 .\[\&\>\*\]\:su-stroke-digital-red>*{stroke:#B1040E}
 .\[\&\>\*\]\:su-font-bold>*{font-weight:700}
-.dark\:\[\&\>\*\]\:su-stroke-dark-mode-red>*:is(.su-dark *){stroke:#EC0909}
+.last\:\[\&\>\*\]\:su-mb-0>*:last-child{margin-bottom:0}
+:is(.su-dark .dark\:\[\&\>\*\]\:su-stroke-dark-mode-red>*){stroke:#EC0909}
+@media (min-width: 992px){
+.lg\:last\:\[\&\>\*\]\:su-mb-0>*:last-child{margin-bottom:0}}
 .\[\&\>li\]\:su-m-0>li{margin:0}
 .\[\&\>p\]\:su-m-0>p{margin:0}
 .\[\&\>p\]\:\!su-mb-0>p{margin-bottom:0 !important}

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -4903,6 +4903,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-min-w-\[17rem\]{min-width:17rem}
 .md\:su-min-w-\[257px\]{min-width:257px}
 .md\:su-max-w-500{max-width:50rem}
+.md\:su-max-w-800{max-width:80rem}
 .md\:su-max-w-\[168px\]{max-width:168px}
 .md\:su-max-w-\[45ch\]{max-width:45ch}
 .md\:su-max-w-\[482px\]{max-width:482px}
@@ -5201,6 +5202,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-w-full{width:100%}
 .lg\:su-min-w-\[38\.2rem\]{min-width:38.2rem}
 .lg\:su-max-w-800{max-width:80rem}
+.lg\:su-max-w-\[118\.6rem\]{max-width:118.6rem}
 .lg\:su-max-w-\[185px\]{max-width:185px}
 .lg\:su-max-w-\[29\.2rem\]{max-width:29.2rem}
 .lg\:su-max-w-\[293px\]{max-width:293px}
@@ -5347,6 +5349,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .\*\:lg\:su-w-\[100px\] > *{width:100px}
 .\*\:lg\:su-max-w-none > *{max-width:none}
 .\*\:lg\:su-basis-1\/3 > *{flex-basis:33.333333%}
+.lg\:\*\:su-basis-1\/2 > *{flex-basis:50%}
 .\*\:lg\:su-text-19 > *{font-size:1.9rem}
 .lg\:\*\:su-text-21 > *{font-size:2.1rem}
 .lg\:\*\:su-text-26 > *{font-size:2.6rem}
@@ -5405,6 +5408,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .xl\:su-flex-row-reverse{flex-direction:row-reverse}
 .xl\:su-gap-40{gap:4rem}
 .xl\:su-gap-60{gap:6rem}
+.xl\:su-px-50{padding-left:5rem;padding-right:5rem}
 .xl\:su-py-100{padding-top:10rem;padding-bottom:10rem}
 .xl\:su-pl-170{padding-left:17rem}
 .xl\:su-text-left{text-align:left}

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -1200,125 +1200,118 @@ div[data-component="footer-component"]{position:relative}
 @media (min-width: 768px){
 .su-page.su-page-story-featured [data-component="text-callout"] > div{width:84.75%}}
 /** 
-  * Updates Page scoped max-width for contents
+  * Updates Page scoped max-width for content elements
 */
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
     .su-page-has-sidebar--left
   )
-  [data-component="text-callout"]
-  > div{width:100%;padding-left:2rem;padding-right:2rem}
-@media (min-width: 576px){
-.su-page:not(
+  [data-component="button"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="button-row"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="pullquote"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div,
+  .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
     .su-page-has-sidebar--left
   )
   [data-component="text-callout"]
-  > div{padding-left:3rem;padding-right:3rem}}
+  > div{width:100%;padding-left:2rem;padding-right:2rem}
 @media (min-width: 768px){
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
     .su-page-has-sidebar--left
   )
-  [data-component="text-callout"]
-  > div{max-width:90rem;padding-left:5rem;padding-right:5rem}}
-@media (min-width: 992px){
-.su-page:not(
+  [data-component="button"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="button-row"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="pullquote"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div,
+  .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
     .su-page-has-sidebar--left
   )
   [data-component="text-callout"]
-  > div{max-width:96rem;padding-left:8rem;padding-right:8rem}}
+  > div{max-width:90rem;padding-left:5rem;padding-right:5rem}}
 @media (min-width: 1200px){
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
     .su-page-has-sidebar--left
   )
+  [data-component="button"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="button-row"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="pullquote"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
   [data-component="text-callout"]
   > div{max-width:80rem;padding-left:0;padding-right:0}}
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="pullquote"]
-  > div{width:100%;padding-left:2rem;padding-right:2rem}
-@media (min-width: 576px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="pullquote"]
-  > div{padding-left:3rem;padding-right:3rem}}
-@media (min-width: 768px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="pullquote"]
-  > div{max-width:90rem;padding-left:5rem;padding-right:5rem}}
-@media (min-width: 992px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="pullquote"]
-  > div{max-width:96rem;padding-left:8rem;padding-right:8rem}}
-@media (min-width: 1200px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="pullquote"]
-  > div{max-width:80rem;padding-left:0;padding-right:0}}
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="single-image-video"]
-  > div{width:100%;padding-left:2rem;padding-right:2rem}
-@media (min-width: 576px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="single-image-video"]
-  > div{padding-left:3rem;padding-right:3rem}}
-@media (min-width: 768px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="single-image-video"]
-  > div{max-width:90rem;padding-left:5rem;padding-right:5rem}}
-@media (min-width: 992px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="single-image-video"]
-  > div{max-width:96rem;padding-left:8rem;padding-right:8rem}}
-@media (min-width: 1200px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="single-image-video"]
-  > div{max-width:80rem;padding-left:0;padding-right:0}}
+/* This overrides the max-width in the container around the title/summary of the Single Image Video
+ * It was inset in the regular view, but we want the title/summary to have the same width and max-width as the image/video
+*/
 @media (min-width: 768px){
 .su-page:not(
     .su-page-story-basic,
@@ -1339,45 +1332,6 @@ div[data-component="footer-component"]{position:relative}
   > div
   > section
   > div{max-width:none}}
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="button-row"]
-  > div{width:100%;padding-left:2rem;padding-right:2rem}
-@media (min-width: 576px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="button-row"]
-  > div{padding-left:3rem;padding-right:3rem}}
-@media (min-width: 768px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="button-row"]
-  > div{max-width:90rem;padding-left:5rem;padding-right:5rem}}
-@media (min-width: 992px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="button-row"]
-  > div{max-width:96rem;padding-left:8rem;padding-right:8rem}}
-@media (min-width: 1200px){
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="button-row"]
-  > div{max-width:80rem;padding-left:0;padding-right:0}}
 .su-page:not(
   .su-page-has-sidebar,
   .su-page-story-featured,
@@ -2592,6 +2546,11 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-rs-mb-3{margin-bottom:4.5rem}}
 @media (min-width: 1500px){
 .su-rs-mb-3{margin-bottom:4.8rem}}
+.su-rs-pb-3{padding-bottom:3.2rem;}
+@media (min-width: 768px){
+.su-rs-pb-3{padding-bottom:4.5rem}}
+@media (min-width: 1500px){
+.su-rs-pb-3{padding-bottom:4.8rem}}
 .su-rs-py-3{padding-top:3.2rem;padding-bottom:3.2rem;}
 @media (min-width: 768px){
 .su-rs-py-3{padding-top:4.5rem;padding-bottom:4.5rem}}
@@ -3709,6 +3668,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-tracking-normal{letter-spacing:0em}
 .\!su-text-digital-red{--tw-text-opacity:1 !important;color:rgb(177 4 14 / var(--tw-text-opacity)) !important}
 .su-text-black{--tw-text-opacity:1;color:rgb(46 45 41 / var(--tw-text-opacity))}
+.su-text-black-30{--tw-text-opacity:1;color:rgb(192 192 191 / var(--tw-text-opacity))}
 .su-text-black-40{--tw-text-opacity:1;color:rgb(171 171 169 / var(--tw-text-opacity))}
 .su-text-black-50{--tw-text-opacity:1;color:rgb(151 150 148 / var(--tw-text-opacity))}
 .su-text-black-60{--tw-text-opacity:1;color:rgb(118 118 116 / var(--tw-text-opacity))}
@@ -4937,7 +4897,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-items-start{align-items:flex-start}
 .md\:su-items-end{align-items:flex-end}
 .md\:su-items-center{align-items:center}
-.md\:su-items-stretch{align-items:stretch}
 .md\:su-justify-start{justify-content:flex-start}
 .md\:su-justify-center{justify-content:center}
 .md\:su-gap-12{gap:1.2rem}
@@ -5247,6 +5206,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-items-start{align-items:flex-start}
 .lg\:su-items-end{align-items:flex-end}
 .lg\:su-items-center{align-items:center}
+.lg\:su-items-stretch{align-items:stretch}
 .lg\:su-justify-end{justify-content:flex-end}
 .lg\:su-justify-center{justify-content:center}
 .lg\:su-gap-0{gap:0}

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -1196,9 +1196,11 @@ div[data-component="footer-component"]{position:relative}
 .su-page-has-sidebar .su-page-sidebar{margin-left:0;margin-right:0;margin-left:auto;margin-right:8.33%;margin-top:0;margin-bottom:9.5rem;max-height:230rem;width:25%;max-width:29.8rem;flex-direction:column;gap:9.5rem;padding-left:0;padding-right:0}}
 .su-page-story-featured .su-upper-content,
 .su-page-story-featured [data-component="feature-story-hero"]{margin-top:0 !important}
-.su-page.su-page-story-featured [data-component="text-callout"] > div{width:100%;max-width:732px}
+.su-page.su-page-story-featured [data-component="text-callout"] > div{width:100%;padding-left:2rem;padding-right:2rem}
 @media (min-width: 768px){
-.su-page.su-page-story-featured [data-component="text-callout"] > div{width:84.75%}}
+.su-page.su-page-story-featured [data-component="text-callout"] > div{width:84.75%;padding-left:5rem;padding-right:5rem}}
+@media (min-width: 1200px){
+.su-page.su-page-story-featured [data-component="text-callout"] > div{max-width:632px;padding-left:0;padding-right:0}}
 /** 
   * Updates Page scoped max-width for content elements
 */
@@ -3134,6 +3136,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-max-h-1000{max-height:100rem}
 .su-max-h-70{max-height:7rem}
 .su-max-h-\[103px\]{max-height:103px}
+.su-min-h-\[5\.6rem\]{min-height:5.6rem}
 .su-min-h-\[56px\]{min-height:56px}
 .su-min-h-full{min-height:100%}
 .\!su-w-full{width:100% !important}
@@ -5201,6 +5204,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-max-w-800{max-width:80rem}
 .lg\:su-max-w-\[185px\]{max-width:185px}
 .lg\:su-max-w-\[29\.2rem\]{max-width:29.2rem}
+.lg\:su-max-w-\[29\.3rem\]{max-width:29.3rem}
 .lg\:su-max-w-\[293px\]{max-width:293px}
 .lg\:su-max-w-\[296px\]{max-width:296px}
 .lg\:su-max-w-\[35\.9rem\]{max-width:35.9rem}

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -1198,9 +1198,9 @@ div[data-component="footer-component"]{position:relative}
 .su-page-story-featured [data-component="feature-story-hero"]{margin-top:0 !important}
 .su-page.su-page-story-featured [data-component="text-callout"] > div{width:100%;padding-left:2rem;padding-right:2rem}
 @media (min-width: 768px){
-.su-page.su-page-story-featured [data-component="text-callout"] > div{width:84.75%;padding-left:5rem;padding-right:5rem}}
+.su-page.su-page-story-featured [data-component="text-callout"] > div{width:84.75%;max-width:73.2rem;padding-left:5rem;padding-right:5rem}}
 @media (min-width: 1200px){
-.su-page.su-page-story-featured [data-component="text-callout"] > div{max-width:632px;padding-left:0;padding-right:0}}
+.su-page.su-page-story-featured [data-component="text-callout"] > div{max-width:63.2rem;padding-left:0;padding-right:0}}
 /** 
   * Updates Page scoped max-width for content elements
 */
@@ -3136,7 +3136,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-max-h-1000{max-height:100rem}
 .su-max-h-70{max-height:7rem}
 .su-max-h-\[103px\]{max-height:103px}
-.su-min-h-\[5\.6rem\]{min-height:5.6rem}
 .su-min-h-\[56px\]{min-height:56px}
 .su-min-h-full{min-height:100%}
 .\!su-w-full{width:100% !important}
@@ -5204,7 +5203,6 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-max-w-800{max-width:80rem}
 .lg\:su-max-w-\[185px\]{max-width:185px}
 .lg\:su-max-w-\[29\.2rem\]{max-width:29.2rem}
-.lg\:su-max-w-\[29\.3rem\]{max-width:29.3rem}
 .lg\:su-max-w-\[293px\]{max-width:293px}
 .lg\:su-max-w-\[296px\]{max-width:296px}
 .lg\:su-max-w-\[35\.9rem\]{max-width:35.9rem}

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -5219,6 +5219,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-translate-x-\[1\.5rem\]{--tw-translate-x:1.5rem;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .lg\:su-translate-y-\[-200px\]{--tw-translate-y:-200px;transform:translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y))}
 .lg\:su-grid-cols-10{grid-template-columns:repeat(10, minmax(0, 1fr))}
+.lg\:su-grid-cols-12{grid-template-columns:repeat(12, minmax(0, 1fr))}
 .lg\:su-grid-cols-3{grid-template-columns:repeat(3, minmax(0, 1fr))}
 .lg\:su-grid-cols-4{grid-template-columns:repeat(4, minmax(0, 1fr))}
 .lg\:su-flex-row{flex-direction:row}
@@ -5265,8 +5266,10 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .lg\:su-p-14{padding:1.4rem}
 .lg\:su-p-38{padding:3.8rem}
 .lg\:su-p-48{padding:4.8rem}
+.lg\:su-px-20{padding-left:2rem;padding-right:2rem}
 .lg\:su-px-65{padding-left:6.5rem;padding-right:6.5rem}
 .lg\:su-px-\[122\.5px\]{padding-left:122.5px;padding-right:122.5px}
+.lg\:su-py-26{padding-top:2.6rem;padding-bottom:2.6rem}
 .lg\:su-py-30{padding-top:3rem;padding-bottom:3rem}
 .lg\:su-py-36{padding-top:3.6rem;padding-bottom:3.6rem}
 .lg\:su-py-61{padding-top:6.1rem;padding-bottom:6.1rem}

--- a/global/css/_global.css
+++ b/global/css/_global.css
@@ -779,7 +779,7 @@ div[data-component="footer-component"] {
 }
 
 .su-page.su-page-story-featured [data-component="text-callout"] > div {
-  @apply su-w-full su-px-20 md:su-px-50 xl:su-px-0 md:su-w-[84.75%] xl:su-max-w-[632px] ;
+  @apply su-w-full su-px-20 md:su-px-50 xl:su-px-0 md:su-w-[84.75%] md:su-max-w-[73.2rem] xl:su-max-w-[63.2rem] ;
 }
 
 /** 

--- a/global/css/_global.css
+++ b/global/css/_global.css
@@ -779,7 +779,7 @@ div[data-component="footer-component"] {
 }
 
 .su-page.su-page-story-featured [data-component="text-callout"] > div {
-  @apply su-w-full su-max-w-[732px] md:su-w-[84.75%];
+  @apply su-w-full su-px-20 md:su-px-50 xl:su-px-0 md:su-w-[84.75%] xl:su-max-w-[632px] ;
 }
 
 /** 

--- a/global/css/_global.css
+++ b/global/css/_global.css
@@ -783,39 +783,49 @@ div[data-component="footer-component"] {
 }
 
 /** 
-  * Updates Page scoped max-width for contents
+  * Updates Page scoped max-width for content elements
 */
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
     .su-page-has-sidebar--left
   )
-  [data-component="text-callout"]
-  > div {
-  @apply su-w-full su-px-20 sm:su-px-30 md:su-px-50 lg:su-px-80 xl:su-px-0 md:su-max-w-900 lg:su-max-w-[96rem] xl:su-max-w-800;
-}
-
-.su-page:not(
+  [data-component="button"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="button-row"]
+  > div,
+  .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
     .su-page-has-sidebar--left
   )
   [data-component="pullquote"]
-  > div {
-  @apply su-w-full su-px-20 sm:su-px-30 md:su-px-50 lg:su-px-80 xl:su-px-0 md:su-max-w-900 lg:su-max-w-[96rem] xl:su-max-w-800;
-}
-
-.su-page:not(
+  > div,
+  .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
     .su-page-has-sidebar--left
   )
   [data-component="single-image-video"]
+  > div,
+  .su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="text-callout"]
   > div {
-  @apply su-w-full su-px-20 sm:su-px-30 md:su-px-50 lg:su-px-80 xl:su-px-0 md:su-max-w-900 lg:su-max-w-[96rem] xl:su-max-w-800;
+  @apply su-w-full su-px-20 md:su-px-50 xl:su-px-0 md:su-max-w-900 xl:su-max-w-800;
 }
 
-/* This overrides the max-width in the container around the title/summary of the Single Image Video */
+/* This overrides the max-width in the container around the title/summary of the Single Image Video
+ * It was inset in the regular view, but we want the title/summary to have the same width and max-width as the image/video
+*/
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
@@ -826,16 +836,6 @@ div[data-component="footer-component"] {
   > section
   > div {
   @apply md:su-max-w-none lg:su-max-w-none;
-}
-
-.su-page:not(
-    .su-page-story-basic,
-    .su-page-story-featured,
-    .su-page-has-sidebar--left
-  )
-  [data-component="button-row"]
-  > div {
-  @apply su-w-full su-px-20 sm:su-px-30 md:su-px-50 lg:su-px-80 xl:su-px-0 md:su-max-w-900 lg:su-max-w-[96rem] xl:su-max-w-800;
 }
 
 .su-page:not(

--- a/global/css/_global.css
+++ b/global/css/_global.css
@@ -778,6 +778,82 @@ div[data-component="footer-component"] {
   @apply su-mt-0 !important;
 }
 
+.su-page.su-page-story-featured [data-component="text-callout"] > div {
+  @apply su-w-full su-max-w-[732px] md:su-w-[84.75%];
+}
+
+/** 
+  * Updates Page scoped max-width for contents
+*/
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="text-callout"]
+  > div {
+  @apply su-w-full su-px-20 sm:su-px-30 md:su-px-50 lg:su-px-80 xl:su-px-0 md:su-max-w-900 lg:su-max-w-[96rem] xl:su-max-w-800;
+}
+
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="pullquote"]
+  > div {
+  @apply su-w-full su-px-20 sm:su-px-30 md:su-px-50 lg:su-px-80 xl:su-px-0 md:su-max-w-900 lg:su-max-w-[96rem] xl:su-max-w-800;
+}
+
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div {
+  @apply su-w-full su-px-20 sm:su-px-30 md:su-px-50 lg:su-px-80 xl:su-px-0 md:su-max-w-900 lg:su-max-w-[96rem] xl:su-max-w-800;
+}
+
+/* This overrides the max-width in the container around the title/summary of the Single Image Video */
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="single-image-video"]
+  > div
+  > section
+  > div {
+  @apply md:su-max-w-none lg:su-max-w-none;
+}
+
+.su-page:not(
+    .su-page-story-basic,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  [data-component="button-row"]
+  > div {
+  @apply su-w-full su-px-20 sm:su-px-30 md:su-px-50 lg:su-px-80 xl:su-px-0 md:su-max-w-900 lg:su-max-w-[96rem] xl:su-max-w-800;
+}
+
+.su-page:not(
+  .su-page-has-sidebar,
+  .su-page-story-featured,
+  .su-page-has-sidebar--left
+)
+  .su-page-content
+  > *:not(
+    [data-component],
+    .container,
+    .su-lower-content,
+    .su-above-footer,
+    .su-upper-content
+  ) {
+  @apply su-w-full su-max-w-900;
+}
+
 /*
 * Containers
 */

--- a/packages/__globalPreview/preview.html
+++ b/packages/__globalPreview/preview.html
@@ -29,6 +29,7 @@
     >
       <div class="su-upper-content"></div>
       <div class="su-page-content">
+        <p>This page is intended to provide members of the university community with timely information about federal policy changes. It will be updated as needed and complements the website maintained by the Vice Provost and Dean of Research to provide information about federal grant programs.</p>
         [component://output]
         <div class="su-lower-content" id="component_130052"></div>
         <div class="su-lower-content"></div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Add max-widths for Button, Button Row, Pullquote, Text Callout, WYSIWYG text, Single Image/Video that are scoped for Updates page
- Fix width regression for Text Callout when used in featured story
- Update Multicolumn Info Section so that its max-width and the padding of its Text Callout on mobile/tablet matches that of other components on the Updates page
- Updates Two Column Text Callout component so that its max width matches other components on the Updates page
- NOTE: @iamrentman please test the standalone text callout in other layouts that you know of

# Review By (Date)
- ASAP

# Criticality
- 10

# Review Tasks

## Setup tasks and/or behavior to test

1. Go to https://news.stanford.edu/developreport/yvonne-test-updates-page/_nocache
2. Verify that the max-widths of Button, Button Row, Pullquote, Text Callout, WYSIWYG text on the page has max-width of 800px - they should all align vertically.
3. Check responsive behavior
4. Check Multicolumn Info Section and responsive behavior
5. Check Two Column Text Callout and responsive behavior
6. Check that all the Text Callouts (standalone, in Multicolumn Info Section, and in Two Column Text Callout) has same widths when they're displayed in a single column on mobile/tablet
![Screenshot 2025-02-26 at 3 03 03 AM](https://github.com/user-attachments/assets/49c34a11-ab9f-46c6-a512-5958d46891e2)
![Screenshot 2025-02-26 at 3 02 50 AM](https://github.com/user-attachments/assets/639609cb-e2dc-483e-9c87-0a49a7f0293d)
7. Go to https://news.stanford.edu/developreport/stories/yvonne-test-story/_nocache and verify that the standalone text callout matches the behavior of that on the live site (compared to https://news.stanford.edu/stories/2025/02/abbas-milani-s-mission-to-preserve-iranian-history)
![Screenshot 2025-02-26 at 3 28 41 AM](https://github.com/user-attachments/assets/b6f88a56-47ad-406e-90f5-5a1c458a2c34)

8. Check that the WYSIWYG, image, pullquote had no regression due to the max-width changes that are scoped to the Updates page


# Associated Issues and/or People
- JIRA ticket(s) - DS-1339, UCP-3959