### PR TITLE
HOTFIX: campaign cta research matters

### DIFF
--- a/global/build/global.css
+++ b/global/build/global.css
@@ -1400,25 +1400,21 @@ div[data-component="footer-component"]{position:relative}
 .su-page-content > [data-component="campaign-cta"]:first-child{margin-top:0}
 .su-page-content > [data-component="campaign-cta"]:last-child{margin-bottom:0}
 /* Campaign CTA on basic story pages */
-.su-page-has-sidebar [data-component="campaign-cta"]{margin-left:-2rem;margin-right:-2rem}
-@media (min-width: 768px){
-.su-page-has-sidebar [data-component="campaign-cta"]{margin-left:calc(-7.65% + 50px);margin-right:calc(-7.65% + 50px);margin-left:calc(calc(-10.75% - 50px));width:calc(121.5% + 100px)}}
-@media (min-width: 992px){
-.su-page-has-sidebar [data-component="campaign-cta"]{margin-left:0;margin-right:0;width:100%}}
+/* .su-page-has-sidebar [data-component="campaign-cta"] {
+  @apply su--mx-20 md:su-mx-[calc(-7.65%+50px)] lg:su-mx-0 md:su-w-[calc(121.5%+100px)] md:su-ml-[calc(calc(-10.75%-50px))] lg:su-w-full;
+}
+
 .su-page-has-sidebar
   [data-component="campaign-cta"]
-  .su-component-campaigncta-wrap{width:100%;padding-left:2rem;padding-right:2rem}
-@media (min-width: 768px){
+  .su-component-campaigncta-wrap {
+  @apply su-w-full su-px-20 md:su-px-50 lg:su-px-60 lg:su-flex-col;
+}
+
 .su-page-has-sidebar
   [data-component="campaign-cta"]
-  .su-component-campaigncta-wrap{padding-left:5rem;padding-right:5rem}}
-@media (min-width: 992px){
-.su-page-has-sidebar
-  [data-component="campaign-cta"]
-  .su-component-campaigncta-wrap{flex-direction:column;padding-left:6rem;padding-right:6rem}
-.su-page-has-sidebar
-  [data-component="campaign-cta"]
-  .su-component-campaigncta-content{margin-right:0;border-style:none}}
+  .su-component-campaigncta-content {
+  @apply lg:su-border-none lg:su-mr-0;
+} */
 /* Medium contextual spacing */
 * + [data-component="pullquote"],
 [data-component="pullquote"] + *,

--- a/global/build/global.css
+++ b/global/build/global.css
@@ -1063,7 +1063,7 @@ audio::-webkit-media-controls-panel {
 * Main page wrapper
 */
 .su-page{width:100%}
-.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left, .su-page-updates)
   .su-page-content
   > *:not(
     [data-component],
@@ -1072,15 +1072,15 @@ audio::-webkit-media-controls-panel {
     .su-above-footer,
     .su-upper-content
   ),
-.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left, .su-page-updates)
   .su-page-content
   > .container
   > *:not([data-component]),
-.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left, .su-page-updates)
   .su-page-content
   > span{margin-left:auto;margin-right:auto;max-width:73.2rem;padding-left:2rem;padding-right:2rem}
 @media (min-width: 768px){
-.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left, .su-page-updates)
   .su-page-content
   > *:not(
     [data-component],
@@ -1089,11 +1089,11 @@ audio::-webkit-media-controls-panel {
     .su-above-footer,
     .su-upper-content
   ),
-.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left, .su-page-updates)
   .su-page-content
   > .container
   > *:not([data-component]),
-.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left, .su-page-updates)
   .su-page-content
   > span{width:84.75%;padding-left:5rem;padding-right:5rem}}
 /* Footer */
@@ -1229,7 +1229,8 @@ div[data-component="footer-component"]{position:relative}
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
-    .su-page-has-sidebar--left
+    .su-page-has-sidebar--left,
+    .su-page-updates
   )
   [data-component="single-image-video"]
   > div,
@@ -1265,7 +1266,8 @@ div[data-component="footer-component"]{position:relative}
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
-    .su-page-has-sidebar--left
+    .su-page-has-sidebar--left,
+    .su-page-updates
   )
   [data-component="single-image-video"]
   > div,
@@ -1301,7 +1303,8 @@ div[data-component="footer-component"]{position:relative}
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
-    .su-page-has-sidebar--left
+    .su-page-has-sidebar--left,
+    .su-page-updates
   )
   [data-component="single-image-video"]
   > div,
@@ -1311,7 +1314,7 @@ div[data-component="footer-component"]{position:relative}
     .su-page-has-sidebar--left
   )
   [data-component="text-callout"]
-  > div{max-width:80rem;padding-left:0;padding-right:0}}
+  > div{max-width:85.867rem;padding-left:0;padding-right:0}}
 /* This overrides the max-width in the container around the title/summary of the Single Image Video
  * It was inset in the regular view, but we want the title/summary to have the same width and max-width as the image/video
 */
@@ -1319,7 +1322,8 @@ div[data-component="footer-component"]{position:relative}
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
-    .su-page-has-sidebar--left
+    .su-page-has-sidebar--left,
+    .su-page-updates
   )
   [data-component="single-image-video"]
   > div
@@ -1329,7 +1333,8 @@ div[data-component="footer-component"]{position:relative}
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
-    .su-page-has-sidebar--left
+    .su-page-has-sidebar--left,
+    .su-page-updates
   )
   [data-component="single-image-video"]
   > div
@@ -1347,7 +1352,68 @@ div[data-component="footer-component"]{position:relative}
     .su-lower-content,
     .su-above-footer,
     .su-upper-content
-  ){width:100%;max-width:90rem}
+  ){margin-left:auto;margin-right:auto;width:100%;max-width:85.867rem;padding-left:2rem;padding-right:2rem}
+@media (min-width: 768px){
+.su-page:not(
+    .su-page-has-sidebar,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  .su-page-content
+  > *:not(
+    [data-component],
+    .container,
+    .su-lower-content,
+    .su-above-footer,
+    .su-upper-content
+  ){padding-left:5rem;padding-right:5rem}}
+@media (min-width: 1200px){
+.su-page:not(
+    .su-page-has-sidebar,
+    .su-page-story-featured,
+    .su-page-has-sidebar--left
+  )
+  .su-page-content
+  > *:not(
+    [data-component],
+    .container,
+    .su-lower-content,
+    .su-above-footer,
+    .su-upper-content
+  ){padding-left:0;padding-right:0}}
+/* Updates page content area grid. */
+/* .su-page.su-page-updates .su-page-content {
+  @apply su-w-full su-max-w-[141.2rem] su-px-20 md:su-px-50 su-grid su-grid-cols-4 sm:su-grid-cols-12 su-grid-gap su-gap-y-0 su-mx-auto;
+}
+
+.su-page.su-page-updates
+  .su-page-content
+  > *:not(
+    [data-component],
+    .container,
+    .su-lower-content,
+    .su-above-footer,
+    .su-upper-content
+  ),
+.su-page.su-page-updates [data-component="button"] > div,
+.su-page.su-page-updates [data-component="button-row"],
+.su-page.su-page-updates [data-component="pullquote"],
+.su-page.su-page-updates [data-component="single-image-video"],
+.su-page.su-page-updates [data-component="text-callout"] {
+  @apply su-col-span-full sm:su-col-start-2 sm:su-col-span-10 lg:su-col-start-2 lg:su-col-span-10 xl:su-col-start-3 xl:su-col-span-8;
+}
+
+.su-page.su-page-updates [data-component="single-image-video"] > div {
+  @apply su-px-20 md:su-px-50 xl:su-px-0;
+}
+
+.su-page.su-page-updates
+  [data-component="single-image-video"]
+  > div
+  > section
+  > div {
+  @apply md:su-max-w-none lg:su-max-w-none;
+} */
 /*
 * Containers
 */
@@ -1399,8 +1465,8 @@ div[data-component="footer-component"]{position:relative}
 /* Campaign CTA */
 .su-page-content > [data-component="campaign-cta"]:first-child{margin-top:0}
 .su-page-content > [data-component="campaign-cta"]:last-child{margin-bottom:0}
-/* Campaign CTA on basic story pages */
-/* .su-page-has-sidebar [data-component="campaign-cta"] {
+/* Campaign CTA on basic story pages
+.su-page-has-sidebar [data-component="campaign-cta"] {
   @apply su--mx-20 md:su-mx-[calc(-7.65%+50px)] lg:su-mx-0 md:su-w-[calc(121.5%+100px)] md:su-ml-[calc(calc(-10.75%-50px))] lg:su-w-full;
 }
 
@@ -1414,7 +1480,7 @@ div[data-component="footer-component"]{position:relative}
   [data-component="campaign-cta"]
   .su-component-campaigncta-content {
   @apply lg:su-border-none lg:su-mr-0;
-} */
+}*/
 /* Medium contextual spacing */
 * + [data-component="pullquote"],
 [data-component="pullquote"] + *,
@@ -2267,14 +2333,23 @@ body.su-page-campaign .center{text-align:center}
 .su-always-dark .su-page-campaign .su-page-content > p a:hover{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .su-always-dark .su-page-campaign .su-page-content > p a:focus{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
 .su-always-dark .su-page-campaign main figcaption{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
-/* Multicolumn image captions on alwaysDark Campaign page. */
-.su-always-dark
-  body.su-page-campaign
-  section[data-component="multicolumn-image"]
-  p{--tw-text-opacity:1;color:rgb(192 192 191 / var(--tw-text-opacity))}
+/*
+  There is a boolean in the Stanford Campaigns schema for always presenting the page dark mode.
+  it applies the .su-always-dark class to the html tag.
+*/
+.su-always-dark body.su-page-campaign{--tw-bg-opacity:1;background-color:rgb(0 0 0 / var(--tw-bg-opacity))}
+.su-always-dark .su-page-campaign main{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+.su-always-dark .su-page-campaign main a{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
+.su-always-dark .su-page-campaign main a:hover{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+.su-always-dark .su-page-campaign main a:focus{--tw-text-opacity:1;color:rgb(236 9 9 / var(--tw-text-opacity))}
+.su-always-dark .su-page-campaign main figcaption{--tw-text-opacity:1;color:rgb(255 255 255 / var(--tw-text-opacity))}
 /* Federal Issues page syle overrides */
 .fed-issues
-  .su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+  .su-page:not(
+    .su-page-has-sidebar,
+    .su-page-has-sidebar--left,
+    .su-page-updates
+  )
   .su-page-content
   > *:not(
     [data-component],
@@ -2981,6 +3056,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .su-m-0{margin:0}
 .\!su-mx-0{margin-left:0 !important;margin-right:0 !important}
 .su--mx-18{margin-left:-1.8rem;margin-right:-1.8rem}
+.su--mx-20{margin-left:-2rem;margin-right:-2rem}
 .su-mx-0{margin-left:0;margin-right:0}
 .su-mx-6{margin-left:0.6rem;margin-right:0.6rem}
 .su-mx-8{margin-left:0.8rem;margin-right:0.8rem}
@@ -4890,6 +4966,7 @@ _::-webkit-full-page-media, _:future, :root .media-feature__thumb img {
 .md\:su-max-w-\[482px\]{max-width:482px}
 .md\:su-max-w-\[60\.7rem\]{max-width:60.7rem}
 .md\:su-max-w-\[65\.5rem\]{max-width:65.5rem}
+.md\:su-max-w-none{max-width:none}
 .md\:su-basis-1\/2{flex-basis:50%}
 .md\:su-basis-1\/3{flex-basis:33.333333%}
 .md\:su-basis-\[39\.5\%\]{flex-basis:39.5%}

--- a/global/css/_global.css
+++ b/global/css/_global.css
@@ -920,7 +920,7 @@ div[data-component="footer-component"] {
 }
 
 /* Campaign CTA on basic story pages */
-.su-page-has-sidebar [data-component="campaign-cta"] {
+/* .su-page-has-sidebar [data-component="campaign-cta"] {
   @apply su--mx-20 md:su-mx-[calc(-7.65%+50px)] lg:su-mx-0 md:su-w-[calc(121.5%+100px)] md:su-ml-[calc(calc(-10.75%-50px))] lg:su-w-full;
 }
 
@@ -934,7 +934,7 @@ div[data-component="footer-component"] {
   [data-component="campaign-cta"]
   .su-component-campaigncta-content {
   @apply lg:su-border-none lg:su-mr-0;
-}
+} */
 
 /* Medium contextual spacing */
 * + [data-component="pullquote"],

--- a/global/css/_global.css
+++ b/global/css/_global.css
@@ -673,7 +673,7 @@ audio::-webkit-media-controls-panel {
   @apply su-w-full;
 }
 
-.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left, .su-page-updates)
   .su-page-content
   > *:not(
     [data-component],
@@ -682,11 +682,11 @@ audio::-webkit-media-controls-panel {
     .su-above-footer,
     .su-upper-content
   ),
-.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left, .su-page-updates)
   .su-page-content
   > .container
   > *:not([data-component]),
-.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+.su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left, .su-page-updates)
   .su-page-content
   > span {
   @apply su-max-w-[73.2rem] md:su-w-[84.75%] su-mx-auto su-px-20 md:su-px-50;
@@ -809,7 +809,8 @@ div[data-component="footer-component"] {
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
-    .su-page-has-sidebar--left
+    .su-page-has-sidebar--left,
+    .su-page-updates
   )
   [data-component="single-image-video"]
   > div,
@@ -820,7 +821,7 @@ div[data-component="footer-component"] {
   )
   [data-component="text-callout"]
   > div {
-  @apply su-w-full su-px-20 md:su-px-50 xl:su-px-0 md:su-max-w-900 xl:su-max-w-800;
+  @apply su-w-full su-px-20 md:su-px-50 xl:su-px-0 md:su-max-w-900 xl:su-max-w-[85.867rem];
 }
 
 /* This overrides the max-width in the container around the title/summary of the Single Image Video
@@ -829,7 +830,8 @@ div[data-component="footer-component"] {
 .su-page:not(
     .su-page-story-basic,
     .su-page-story-featured,
-    .su-page-has-sidebar--left
+    .su-page-has-sidebar--left,
+    .su-page-updates
   )
   [data-component="single-image-video"]
   > div
@@ -851,8 +853,42 @@ div[data-component="footer-component"] {
     .su-above-footer,
     .su-upper-content
   ) {
-  @apply su-w-full su-max-w-900;
+  @apply su-w-full su-mx-auto su-px-20 md:su-px-50 xl:su-px-0 su-max-w-[85.867rem];
 }
+
+/* Updates page content area grid. */
+/* .su-page.su-page-updates .su-page-content {
+  @apply su-w-full su-max-w-[141.2rem] su-px-20 md:su-px-50 su-grid su-grid-cols-4 sm:su-grid-cols-12 su-grid-gap su-gap-y-0 su-mx-auto;
+}
+
+.su-page.su-page-updates
+  .su-page-content
+  > *:not(
+    [data-component],
+    .container,
+    .su-lower-content,
+    .su-above-footer,
+    .su-upper-content
+  ),
+.su-page.su-page-updates [data-component="button"] > div,
+.su-page.su-page-updates [data-component="button-row"],
+.su-page.su-page-updates [data-component="pullquote"],
+.su-page.su-page-updates [data-component="single-image-video"],
+.su-page.su-page-updates [data-component="text-callout"] {
+  @apply su-col-span-full sm:su-col-start-2 sm:su-col-span-10 lg:su-col-start-2 lg:su-col-span-10 xl:su-col-start-3 xl:su-col-span-8;
+}
+
+.su-page.su-page-updates [data-component="single-image-video"] > div {
+  @apply su-px-20 md:su-px-50 xl:su-px-0;
+}
+
+.su-page.su-page-updates
+  [data-component="single-image-video"]
+  > div
+  > section
+  > div {
+  @apply md:su-max-w-none lg:su-max-w-none;
+} */
 
 /*
 * Containers
@@ -919,8 +955,8 @@ div[data-component="footer-component"] {
   @apply su-mb-0;
 }
 
-/* Campaign CTA on basic story pages */
-/* .su-page-has-sidebar [data-component="campaign-cta"] {
+/* Campaign CTA on basic story pages
+.su-page-has-sidebar [data-component="campaign-cta"] {
   @apply su--mx-20 md:su-mx-[calc(-7.65%+50px)] lg:su-mx-0 md:su-w-[calc(121.5%+100px)] md:su-ml-[calc(calc(-10.75%-50px))] lg:su-w-full;
 }
 
@@ -934,7 +970,7 @@ div[data-component="footer-component"] {
   [data-component="campaign-cta"]
   .su-component-campaigncta-content {
   @apply lg:su-border-none lg:su-mr-0;
-} */
+}*/
 
 /* Medium contextual spacing */
 * + [data-component="pullquote"],
@@ -1449,17 +1485,33 @@ body.su-page-campaign .center {
   @apply su-text-white;
 }
 
-/* Multicolumn image captions on alwaysDark Campaign page. */
-.su-always-dark
-  body.su-page-campaign
-  section[data-component="multicolumn-image"]
-  p {
-  @apply su-text-black-30;
+/*
+  There is a boolean in the Stanford Campaigns schema for always presenting the page dark mode.
+  it applies the .su-always-dark class to the html tag.
+*/
+.su-always-dark body.su-page-campaign {
+  @apply su-bg-black-true;
+}
+
+.su-always-dark .su-page-campaign main {
+  @apply su-text-white;
+}
+
+.su-always-dark .su-page-campaign main a {
+  @apply su-text-white hocus:su-text-dark-mode-red;
+}
+
+.su-always-dark .su-page-campaign main figcaption {
+  @apply su-text-white;
 }
 
 /* Federal Issues page syle overrides */
 .fed-issues
-  .su-page:not(.su-page-has-sidebar, .su-page-has-sidebar--left)
+  .su-page:not(
+    .su-page-has-sidebar,
+    .su-page-has-sidebar--left,
+    .su-page-updates
+  )
   .su-page-content
   > *:not(
     [data-component],


### PR DESCRIPTION
Removes (comments out) Campaign CTA styles scoped to `.su-page-has-sidebar` in the `_global.css` file so that the component displays the same on all story pages.